### PR TITLE
Added a line for extended description for numpy style

### DIFF
--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -64,6 +64,8 @@ call add(b:doge_patterns, {
 \      'numpy': [
 \        '"""',
 \        'TODO',
+\        '',
+\        'TODO',
 \        '#(parameters|)',
 \        '#(parameters|Parameters)',
 \        '#(parameters|----------)',

--- a/test/filetypes/python/functions.vader
+++ b/test/filetypes/python/functions.vader
@@ -109,6 +109,8 @@ Expect python (generated comment with nothing but the text 'TODO'):
   def myFunc():
       """
       TODO
+      
+      TODO
       """
       pass
 
@@ -125,6 +127,8 @@ Do (trigger doge):
 Expect python (generated comment with :param tags):
   def myFunc(p1: Callable[[int], None] = False, p2: Callable[[int, Exception], None] = {}):
       """
+      TODO
+      
       TODO
       
       Parameters
@@ -149,6 +153,8 @@ Do (trigger doge):
 Expect python (generated comment with :param tags):
   def myFunc(p1: Callable[[int], None] = False, p2: Callable[[int, Exception], None] = {}) -> Sequence[T]:
       """
+      TODO
+      
       TODO
       
       Parameters


### PR DESCRIPTION
# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Put an `x` inside every [ ] you agree with)**:
- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

According to the following link: https://docs.python-guide.org/writing/documentation/ there should be two sections with the numpy style guide. The first should be a summary
line, and then there should be a more detailed, extended description of
the function. This PR will add this extra TODO item for an extended
description.
