### PR TITLE
Fix catch "Pattern not found"/"Unknown function" when locale is not en

### DIFF
--- a/autoload/doge/generate.vim
+++ b/autoload/doge/generate.vim
@@ -38,7 +38,7 @@ function! doge#generate#pattern(pattern) abort
   try
     let l:preprocess_fn = printf('doge#preprocessors#%s#tokens', &filetype)
     call function(l:preprocess_fn)(l:tokens)
-  catch /E117: Unknown function/
+  catch /^Vim\%((\a\+)\)\=:E117/
   endtry
 
   " Split the 'parameters' token value into a list.
@@ -59,7 +59,7 @@ function! doge#generate#pattern(pattern) abort
     try
       let l:preprocess_fn = printf('doge#preprocessors#%s#parameter_tokens', &filetype)
       call function(l:preprocess_fn)(l:param_tokens)
-    catch /E117: Unknown function/
+    catch /^Vim\%((\a\+)\)\=:E117/
     endtry
 
     for l:param_token in l:param_tokens
@@ -121,7 +121,7 @@ function! doge#generate#pattern(pattern) abort
     let l:preprocess_fn = printf('doge#preprocessors#%s#insert_position', &filetype)
     let l:preprocessed_insert_position = function(l:preprocess_fn)(l:comment_lnum_insert_position)
     let l:comment_lnum_insert_position = l:preprocessed_insert_position
-  catch /E117: Unknown function/
+  catch /^Vim\%((\a\+)\)\=:E117/
   endtry
 
   " Write the comment.

--- a/autoload/doge/helpers.vim
+++ b/autoload/doge/helpers.vim
@@ -25,7 +25,7 @@ function! doge#helpers#count(word, ...) abort
   endif
   try
     let l:cnt = execute(l:range . 's/' . a:word . '//gn')
-  catch /E486: Pattern not found/
+  catch /^Vim\%((\a\+)\)\=:E486/
     return 0
   endtry
   call setpos('.', l:cursor_pos)


### PR DESCRIPTION
# Why this PR?

The plugin does not work when vim locale is not en; i.e. for python files it raises an error on `<C-D>`:
```
Wykryto błąd podczas przetwarzania function doge#generate[3]..doge#generate#pattern:
wiersz   33:
E117: Nieznana funkcja: doge#preprocessors#python#tokens
Wykryto błąd podczas przetwarzania function doge#generate:
wiersz    3:
E171: Brak :endif 
```
 When calling not-existing functions, vim generates localized errors messages that do not match
catch statements in the plugin.

This patch replaces the current catching method for `E117` and `E486` by one method from `:h catch`: `catch /^Vim\%((\a\+)\)\=:<error number>/`
