### PR TITLE
Add support for Sphinx format

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,21 +56,21 @@ Is your favorite language not supported?
 Is your favorite doc standard not supported?
 [Suggest a new doc standard][suggest-doc-standard] :tada:
 
-|                    | Language                                       | Doc standards                                           |
-| :----------------- | :--------------------------------------------- | :------------------------------------------------------ |
-| :white_check_mark: | Python                                         | [reST][py-reST], [Numpy][py-numpy], [Google][py-google] |
-| :white_check_mark: | PHP                                            | [phpdoc][phpdoc]                                        |
-| :white_check_mark: | JavaScript (Including: ES6, FlowJS and NodeJS) | [JSDoc][jsdoc]                                          |
-| :white_check_mark: | TypeScript                                     | [JSDoc][jsdoc]                                          |
-| :white_check_mark: | CoffeeScript                                   | [JSDoc][jsdoc]                                          |
-| :white_check_mark: | Lua                                            | [LDoc][ldoc]                                            |
-| :white_check_mark: | Java                                           | [JavaDoc][javadoc]                                      |
-| :white_check_mark: | Groovy                                         | [JavaDoc][javadoc]                                      |
-| :white_check_mark: | Ruby                                           | [YARD][YARD]                                            |
-| :white_check_mark: | Scala                                          | [ScalaDoc][scaladoc]                                    |
-| :white_check_mark: | Kotlin                                         | [KDoc][kdoc]                                            |
-| :white_check_mark: | R                                              | [Roxygen2][roxygen2]                                    |
-| :white_check_mark: | C++                                            | [Doxygen][doxygen]                                      |
+|                    | Language                                       | Doc standards                                                                |
+| :----------------- | :--------------------------------------------- | :--------------------------------------------------------------------------- |
+| :white_check_mark: | Python                                         | [reST][py-reST], [Numpy][py-numpy], [Google][py-google], [Sphinx][py-sphinx] |
+| :white_check_mark: | PHP                                            | [phpdoc][phpdoc]                                                             |
+| :white_check_mark: | JavaScript (Including: ES6, FlowJS and NodeJS) | [JSDoc][jsdoc]                                                               |
+| :white_check_mark: | TypeScript                                     | [JSDoc][jsdoc]                                                               |
+| :white_check_mark: | CoffeeScript                                   | [JSDoc][jsdoc]                                                               |
+| :white_check_mark: | Lua                                            | [LDoc][ldoc]                                                                 |
+| :white_check_mark: | Java                                           | [JavaDoc][javadoc]                                                           |
+| :white_check_mark: | Groovy                                         | [JavaDoc][javadoc]                                                           |
+| :white_check_mark: | Ruby                                           | [YARD][YARD]                                                                 |
+| :white_check_mark: | Scala                                          | [ScalaDoc][scaladoc]                                                         |
+| :white_check_mark: | Kotlin                                         | [KDoc][kdoc]                                                                 |
+| :white_check_mark: | R                                              | [Roxygen2][roxygen2]                                                         |
+| :white_check_mark: | C++                                            | [Doxygen][doxygen]                                                           |
 
 # Getting started
 
@@ -221,6 +221,7 @@ DoGe is licensed under the GPL-3.0 license.
 [py-reST]: http://daouzli.com/blog/docstring.html#restructuredtext
 [py-numpy]: http://daouzli.com/blog/docstring.html#numpydoc
 [py-google]: https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
+[py-sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html#the-sphinx-docstring-format
 [phpdoc]: https://www.phpdoc.org
 [jsdoc]: https://jsdoc.app
 [ldoc]: https://github.com/stevedonovan/LDoc

--- a/README.md
+++ b/README.md
@@ -111,21 +111,21 @@ If you want to change the doc standard specifically for a buffer you can do:
 
 Here is the full list of available doc standards per filetype:
 
-| Variable                           | Default      | Supported                       |
-| :--------------------------------- | :----------- | :------------------------------ |
-| `g:doge_doc_standard_python`       | `'reST'`     | `'reST'`, `'numpy'`, `'google'` |
-| `g:doge_doc_standard_php`          | `'phpdoc'`   | `'phpdoc'`                      |
-| `g:doge_doc_standard_javascript`   | `'jsdoc'`    | `'jsdoc'`                       |
-| `g:doge_doc_standard_typescript`   | `'jsdoc'`    | `'jsdoc'`                       |
-| `g:doge_doc_standard_coffeescript` | `'jsdoc'`    | `'jsdoc'`                       |
-| `g:doge_doc_standard_lua`          | `'ldoc'`     | `'ldoc'`                        |
-| `g:doge_doc_standard_java`         | `'javadoc'`  | `'javadoc'`                     |
-| `g:doge_doc_standard_groovy`       | `'javadoc'`  | `'javadoc'`                     |
-| `g:doge_doc_standard_ruby`         | `'YARD'`     | `'YARD'`                        |
-| `g:doge_doc_standard_scala`        | `'scaladoc'` | `'scaladoc'`                    |
-| `g:doge_doc_standard_kotlin`       | `'kdoc'`     | `'kdoc'`                        |
-| `g:doge_doc_standard_r`            | `'roxygen2'` | `'roxygen2'`                    |
-| `g:doge_doc_standard_cpp`          | `'doxygen'`  | `'doxygen'`                     |
+| Variable                           | Default      | Supported                                   |
+| :--------------------------------- | :----------- | :------------------------------------------ |
+| `g:doge_doc_standard_python`       | `'reST'`     | `'reST'`, `'numpy'`, `'google'`, `'sphinx'` |
+| `g:doge_doc_standard_php`          | `'phpdoc'`   | `'phpdoc'`                                  |
+| `g:doge_doc_standard_javascript`   | `'jsdoc'`    | `'jsdoc'`                                   |
+| `g:doge_doc_standard_typescript`   | `'jsdoc'`    | `'jsdoc'`                                   |
+| `g:doge_doc_standard_coffeescript` | `'jsdoc'`    | `'jsdoc'`                                   |
+| `g:doge_doc_standard_lua`          | `'ldoc'`     | `'ldoc'`                                    |
+| `g:doge_doc_standard_java`         | `'javadoc'`  | `'javadoc'`                                 |
+| `g:doge_doc_standard_groovy`       | `'javadoc'`  | `'javadoc'`                                 |
+| `g:doge_doc_standard_ruby`         | `'YARD'`     | `'YARD'`                                    |
+| `g:doge_doc_standard_scala`        | `'scaladoc'` | `'scaladoc'`                                |
+| `g:doge_doc_standard_kotlin`       | `'kdoc'`     | `'kdoc'`                                    |
+| `g:doge_doc_standard_r`            | `'roxygen2'` | `'roxygen2'`                                |
+| `g:doge_doc_standard_cpp`          | `'doxygen'`  | `'doxygen'`                                 |
 
 ## Options
 

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -46,8 +46,8 @@ call add(b:doge_patterns, {
 \    'format': {
 \      'reST': ':param {name} {type|' . doge#helpers#placeholder('type') . '}: TODO',
 \      'sphinx': [
-\        ':param {name}: TODO',
-\        ':type {name}: {type|' . doge#helpers#placeholder('type') . '}'
+\        ':param {name}: TODO#(default|, defaults to {default})',
+\        ':type {name} : {type|' . doge#helpers#placeholder('type') . '}#(default|, optional)'
 \      ],
 \      'numpy': [
 \        '{name} : {type|' . doge#helpers#placeholder('type') . '}',

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -12,7 +12,7 @@ set cpoptions&vim
 let b:doge_pattern_single_line_comment = '\m#.\{-}$'
 let b:doge_pattern_multi_line_comment = '\m\(""".\{-}"""\|' . "'''.\\{-}'''" . '\)'
 
-let b:doge_supported_doc_standards = ['reST', 'numpy', 'google']
+let b:doge_supported_doc_standards = ['reST', 'numpy', 'google', 'sphinx']
 let b:doge_doc_standard = get(g:, 'doge_doc_standard_python', 'reST')
 if index(b:doge_supported_doc_standards, b:doge_doc_standard) < 0
   echoerr printf(
@@ -45,6 +45,10 @@ call add(b:doge_patterns, {
 \    'match_group_names': ['name', 'type', 'default'],
 \    'format': {
 \      'reST': ':param {name} {type|' . doge#helpers#placeholder('type') . '}: TODO',
+\      'sphinx': [
+\        ':param {name}: TODO',
+\        ':type {name}: {type|' . doge#helpers#placeholder('type') . '}'
+\      ],
 \      'numpy': [
 \        '{name} : {type|' . doge#helpers#placeholder('type') . '}',
 \        "\tTODO",
@@ -63,6 +67,15 @@ call add(b:doge_patterns, {
 \        '',
 \        '#(parameters|{parameters})',
 \        '#(returnType|:rtype {returnType}: TODO)',
+\        '"""',
+\      ],
+\      'sphinx': [
+\        '"""',
+\        'TODO',
+\        '',
+\        '#(parameters|{parameters})',
+\        ':return: TODO',
+\        '#(returnType|:rtype: {returnType})',
 \        '"""',
 \      ],
 \      'numpy': [

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -4,6 +4,7 @@
 " - reST: http://daouzli.com/blog/docstring.html#restructuredtext
 " - Numpy: http://daouzli.com/blog/docstring.html#numpydoc
 " - Google: https://github.com/google/styleguide/blob/gh-pages/pyguide.md
+" - Sphinx: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html#the-sphinx-docstring-format
 " ==============================================================================
 
 let s:save_cpo = &cpoptions

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -4,7 +4,7 @@
 " - reST: http://daouzli.com/blog/docstring.html#restructuredtext
 " - Numpy: http://daouzli.com/blog/docstring.html#numpydoc
 " - Google: https://github.com/google/styleguide/blob/gh-pages/pyguide.md
-" - Sphinx: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html#the-sphinx-docstring-format
+" - Sphinx: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
 " ==============================================================================
 
 let s:save_cpo = &cpoptions

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -47,7 +47,7 @@ call add(b:doge_patterns, {
 \      'reST': ':param {name} {type|' . doge#helpers#placeholder('type') . '}: TODO',
 \      'sphinx': [
 \        ':param {name}: TODO#(default|, defaults to {default})',
-\        ':type {name} : {type|' . doge#helpers#placeholder('type') . '}#(default|, optional)'
+\        ':type {name}: {type|' . doge#helpers#placeholder('type') . '}#(default|, optional)'
 \      ],
 \      'numpy': [
 \        '{name} : {type|' . doge#helpers#placeholder('type') . '}',
@@ -74,7 +74,7 @@ call add(b:doge_patterns, {
 \        'TODO',
 \        '',
 \        '#(parameters|{parameters})',
-\        ':return: TODO',
+\        '#(returnType|:return: TODO)',
 \        '#(returnType|:rtype: {returnType})',
 \        '"""',
 \      ],

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -47,7 +47,7 @@ call add(b:doge_patterns, {
 \      'reST': ':param {name} {type|' . doge#helpers#placeholder('type') . '}: TODO',
 \      'sphinx': [
 \        ':param {name}: TODO#(default|, defaults to {default})',
-\        ':type {name}: {type|' . doge#helpers#placeholder('type') . '}#(default|, optional)'
+\        ':type {name}: {type|' . doge#helpers#placeholder('type') . '}#(default|, optional)',
 \      ],
 \      'numpy': [
 \        '{name} : {type|' . doge#helpers#placeholder('type') . '}',

--- a/test/filetypes/python/functions-doc-sphinx.vader
+++ b/test/filetypes/python/functions-doc-sphinx.vader
@@ -14,7 +14,6 @@ Expect python (generated comment with nothing but the summary and description 'T
       """
       TODO
       
-      :return: TODO
       """
       pass
 
@@ -28,18 +27,17 @@ Do (trigger doge):
   :let b:doge_doc_standard='sphinx'\<CR>
   \<C-d>
 
-Expect python (generated comment with Args tags):
+Expect python (generated comment with defaults and optional):
   def myFunc(p1, p2, p3 = ''):
       """
       TODO
       
       :param p1: TODO
-      :type p1 : [TODO:type]
+      :type p1: [TODO:type]
       :param p2: TODO
-      :type p2 : [TODO:type]
+      :type p2: [TODO:type]
       :param p3: TODO, defaults to ''
-      :type p3 : [TODO:type], optional
-      :return: TODO
+      :type p3: [TODO:type], optional
       """
       pass
 
@@ -53,18 +51,17 @@ Do (trigger doge):
   :let b:doge_doc_standard='sphinx'\<CR>
   \<C-d>
 
-Expect python (generated comment with Args tags):
+Expect python (generated comment with types, defaults and optional):
   def myFunc(p1, p2: Callable[[int], None], p3: Callable[[int, Exception], None] = []):
       """
       TODO
       
       :param p1: TODO
-      :type p1 : [TODO:type]
+      :type p1: [TODO:type]
       :param p2: TODO
-      :type p2 : Callable[[int], None]
+      :type p2: Callable[[int], None]
       :param p3: TODO, defaults to []
-      :type p3 : Callable[[int, Exception], None], optional
-      :return: TODO
+      :type p3: Callable[[int, Exception], None], optional
       """
       pass
 
@@ -84,11 +81,11 @@ Expect python (generated comment with Args and Returns tags):
       TODO
       
       :param p1: TODO
-      :type p1 : [TODO:type]
+      :type p1: [TODO:type]
       :param p2: TODO
-      :type p2 : Callable[[int], None]
+      :type p2: Callable[[int], None]
       :param p3: TODO, defaults to []
-      :type p3 : Callable[[int, Exception], None], optional
+      :type p3: Callable[[int, Exception], None], optional
       :return: TODO
       :rtype: Sequence[T]
       """

--- a/test/filetypes/python/functions-doc-sphinx.vader
+++ b/test/filetypes/python/functions-doc-sphinx.vader
@@ -6,6 +6,7 @@ Given python (function without parameters):
     pass
 
 Do (trigger doge):
+  :let b:doge_doc_standard_python='sphinx'\<CR>
   \<C-d>
 
 Expect python (no changes):
@@ -22,9 +23,10 @@ Expect python (no changes):
 # ==============================================================================
 Given python (function without type hints):
   def myFunc(p1 = 'string', p2 = 5, p3, p4):
-    pass
+ a  pass
 
 Do (trigger doge):
+  :let b:doge_doc_standard_python='sphinx'\<CR>
   \<C-d>
 
 Expect python (generated comment with :param tags):
@@ -52,6 +54,7 @@ Given python (function with parameters):
       pass
 
 Do (trigger doge):
+  :let b:doge_doc_standard_python='sphinx'\<CR>
   \<C-d>
 
 Expect python (generated comment with :param tags):
@@ -78,8 +81,9 @@ Given python (functions with advanced type hint parameters):
       pass
 
 Do (trigger doge):
+  :let b:doge_doc_standard_python='sphinx'\<CR>
   \<C-d>
-  11j
+  :14\<CR>
   \<C-d>
 
 Expect python (generated comments with :param tags):
@@ -118,6 +122,7 @@ Given python (multi-line function with type hint parameters):
       pass
 
 Do (trigger doge):
+  :let b:doge_doc_standard_python='sphinx'\<CR>
   \<C-d>
 
 Expect python (generated comment with :param and :rtype tags):

--- a/test/filetypes/python/functions-doc-sphinx.vader
+++ b/test/filetypes/python/functions-doc-sphinx.vader
@@ -1,10 +1,9 @@
 # ==============================================================================
-# Functions using the Google doc standard.
+# Functions using the Sphinx doc standard.
 # ==============================================================================
 Given python(function without paramters without return type where b:doge_doc_standard='sphinx'):
   def myFunc():
       pass
-
 
 Do (trigger doge):
   :let b:doge_doc_standard='sphinx'\<CR>
@@ -35,11 +34,11 @@ Expect python (generated comment with Args tags):
       TODO
       
       :param p1: TODO
-      :type p1: [TODO:type]
+      :type p1 : [TODO:type]
       :param p2: TODO
-      :type p2: [TODO:type]
-      :param p3: TODO
-      :type p3: [TODO:type]
+      :type p2 : [TODO:type]
+      :param p3: TODO, defaults to ''
+      :type p3 : [TODO:type], optional
       :return: TODO
       """
       pass
@@ -60,11 +59,11 @@ Expect python (generated comment with Args tags):
       TODO
       
       :param p1: TODO
-      :type p1: [TODO:type]
+      :type p1 : [TODO:type]
       :param p2: TODO
-      :type p2: Callable[[int], None]
-      :param p3: TODO
-      :type p3: Callable[[int, Exception], None]
+      :type p2 : Callable[[int], None]
+      :param p3: TODO, defaults to []
+      :type p3 : Callable[[int, Exception], None], optional
       :return: TODO
       """
       pass
@@ -85,11 +84,11 @@ Expect python (generated comment with Args and Returns tags):
       TODO
       
       :param p1: TODO
-      :type p1: [TODO:type]
+      :type p1 : [TODO:type]
       :param p2: TODO
-      :type p2: Callable[[int], None]
-      :param p3: TODO
-      :type p3: Callable[[int, Exception], None]
+      :type p2 : Callable[[int], None]
+      :param p3: TODO, defaults to []
+      :type p3 : Callable[[int, Exception], None], optional
       :return: TODO
       :rtype: Sequence[T]
       """

--- a/test/filetypes/python/functions-doc-sphinx.vader
+++ b/test/filetypes/python/functions-doc-sphinx.vader
@@ -9,7 +9,7 @@ Do (trigger doge):
   :let b:doge_doc_standard='sphinx'\<CR>
   \<C-d>
 
-Expect python (generated comment with nothing but the summary and description 'TODO'):
+Expect python (generated comment with nothing but the text 'TODO):
   def myFunc():
       """
       TODO
@@ -27,7 +27,7 @@ Do (trigger doge):
   :let b:doge_doc_standard='sphinx'\<CR>
   \<C-d>
 
-Expect python (generated comment with defaults and optional):
+Expect python (generated comment without type hints with defaults and optional):
   def myFunc(p1, p2, p3 = ''):
       """
       TODO
@@ -51,7 +51,7 @@ Do (trigger doge):
   :let b:doge_doc_standard='sphinx'\<CR>
   \<C-d>
 
-Expect python (generated comment with types, defaults and optional):
+Expect python (generated comment with type hints, defaults and optional):
   def myFunc(p1, p2: Callable[[int], None], p3: Callable[[int, Exception], None] = []):
       """
       TODO
@@ -75,7 +75,7 @@ Do (trigger doge):
   :let b:doge_doc_standard='sphinx'\<CR>
   \<C-d>
 
-Expect python (generated comment with Args and Returns tags):
+Expect python (generated comment with :param, :type, :return and :rtype tags):
   def myFunc(p1, p2: Callable[[int], None], p3: Callable[[int, Exception], None] = []) -> Sequence[T]:
       """
       TODO

--- a/test/filetypes/python/functions-doc-sphinx.vader
+++ b/test/filetypes/python/functions-doc-sphinx.vader
@@ -1,0 +1,140 @@
+# ==============================================================================
+# Functions without parameters.
+# ==============================================================================
+Given python (function without parameters):
+  def myFunc(): # inline comment
+    pass
+
+Do (trigger doge):
+  \<C-d>
+
+Expect python (no changes):
+  def myFunc(): # inline comment
+    """
+    TODO
+    
+    :return: TODO
+    """
+    pass
+
+# ==============================================================================
+# Functions without type hints.
+# ==============================================================================
+Given python (function without type hints):
+  def myFunc(p1 = 'string', p2 = 5, p3, p4):
+    pass
+
+Do (trigger doge):
+  \<C-d>
+
+Expect python (generated comment with :param tags):
+  def myFunc(p1 = 'string', p2 = 5, p3, p4):
+    """
+    TODO
+    
+    :param p1: TODO
+    :type p1: [TODO:type]
+    :param p2: TODO
+    :type p2: [TODO:type]
+    :param p3: TODO
+    :type p3: [TODO:type]
+    :param p4: TODO
+    :type p4: [TODO:type]
+    :return: TODO
+    """
+    pass
+
+# ==============================================================================
+# Functions with parameters.
+# ==============================================================================
+Given python (function with parameters):
+  def myFunc(p1: str = 'string', p2: int = 5):
+      pass
+
+Do (trigger doge):
+  \<C-d>
+
+Expect python (generated comment with :param tags):
+  def myFunc(p1: str = 'string', p2: int = 5):
+      """
+      TODO
+      
+      :param p1: TODO
+      :type p1: str
+      :param p2: TODO
+      :type p2: int
+      :return: TODO
+      """
+      pass
+
+# ==============================================================================
+# Functions with advanced type hint parameters.
+# ==============================================================================
+Given python (functions with advanced type hint parameters):
+  def myFunc(p1: Callable[[int], None] = False, p2: Callable[[int, Exception], None] = {}) -> Sequence[T]:
+      pass
+
+  def myFunc(p1: Sequence[T], p2: my_module.types) -> Generator[int, float, str]:
+      pass
+
+Do (trigger doge):
+  \<C-d>
+  11j
+  \<C-d>
+
+Expect python (generated comments with :param tags):
+  def myFunc(p1: Callable[[int], None] = False, p2: Callable[[int, Exception], None] = {}) -> Sequence[T]:
+      """
+      TODO
+      
+      :param p1: TODO
+      :type p1: Callable[[int], None]
+      :param p2: TODO
+      :type p2: Callable[[int, Exception], None]
+      :return: TODO
+      :rtype: Sequence[T]
+      """
+      pass
+
+  def myFunc(p1: Sequence[T], p2: my_module.types) -> Generator[int, float, str]:
+      """
+      TODO
+      
+      :param p1: TODO
+      :type p1: Sequence[T]
+      :param p2: TODO
+      :type p2: my_module.types
+      :return: TODO
+      :rtype: Generator[int, float, str]
+      """
+      pass
+
+# ==============================================================================
+# Functions defined multi-line.
+# ==============================================================================
+Given python (multi-line function with type hint parameters):
+  def myFunc(p1: str, p2: dict,
+          p3: list, p4: tuple) -> Iterator[int]:
+      pass
+
+Do (trigger doge):
+  \<C-d>
+
+Expect python (generated comment with :param and :rtype tags):
+  def myFunc(p1: str, p2: dict,
+          p3: list, p4: tuple) -> Iterator[int]:
+      """
+      TODO
+      
+      :param p1: TODO
+      :type p1: str
+      :param p2: TODO
+      :type p2: dict
+      :param p3: TODO
+      :type p3: list
+      :param p4: TODO
+      :type p4: tuple
+      :return: TODO
+      :rtype: Iterator[int]
+      """
+      pass

--- a/test/filetypes/python/functions-doc-sphinx.vader
+++ b/test/filetypes/python/functions-doc-sphinx.vader
@@ -1,145 +1,96 @@
 # ==============================================================================
-# Functions without parameters.
+# Functions using the Google doc standard.
 # ==============================================================================
-Given python (function without parameters):
-  def myFunc(): # inline comment
-    pass
-
-Do (trigger doge):
-  :let b:doge_doc_standard_python='sphinx'\<CR>
-  \<C-d>
-
-Expect python (no changes):
-  def myFunc(): # inline comment
-    """
-    TODO
-    
-    :return: TODO
-    """
-    pass
-
-# ==============================================================================
-# Functions without type hints.
-# ==============================================================================
-Given python (function without type hints):
-  def myFunc(p1 = 'string', p2 = 5, p3, p4):
- a  pass
-
-Do (trigger doge):
-  :let b:doge_doc_standard_python='sphinx'\<CR>
-  \<C-d>
-
-Expect python (generated comment with :param tags):
-  def myFunc(p1 = 'string', p2 = 5, p3, p4):
-    """
-    TODO
-    
-    :param p1: TODO
-    :type p1: [TODO:type]
-    :param p2: TODO
-    :type p2: [TODO:type]
-    :param p3: TODO
-    :type p3: [TODO:type]
-    :param p4: TODO
-    :type p4: [TODO:type]
-    :return: TODO
-    """
-    pass
-
-# ==============================================================================
-# Functions with parameters.
-# ==============================================================================
-Given python (function with parameters):
-  def myFunc(p1: str = 'string', p2: int = 5):
+Given python(function without paramters without return type where b:doge_doc_standard='sphinx'):
+  def myFunc():
       pass
 
+
 Do (trigger doge):
-  :let b:doge_doc_standard_python='sphinx'\<CR>
+  :let b:doge_doc_standard='sphinx'\<CR>
   \<C-d>
 
-Expect python (generated comment with :param tags):
-  def myFunc(p1: str = 'string', p2: int = 5):
+Expect python (generated comment with nothing but the summary and description 'TODO'):
+  def myFunc():
       """
       TODO
       
-      :param p1: TODO
-      :type p1: str
-      :param p2: TODO
-      :type p2: int
       :return: TODO
       """
       pass
 
-# ==============================================================================
-# Functions with advanced type hint parameters.
-# ==============================================================================
-Given python (functions with advanced type hint parameters):
-  def myFunc(p1: Callable[[int], None] = False, p2: Callable[[int, Exception], None] = {}) -> Sequence[T]:
-      pass
+# ------------------------------------------------------------------------------
 
-  def myFunc(p1: Sequence[T], p2: my_module.types) -> Generator[int, float, str]:
+Given python(function with parameters without type hints without return type where b:doge_doc_standard='sphinx'):
+  def myFunc(p1, p2, p3 = ''):
       pass
 
 Do (trigger doge):
-  :let b:doge_doc_standard_python='sphinx'\<CR>
-  \<C-d>
-  :14\<CR>
+  :let b:doge_doc_standard='sphinx'\<CR>
   \<C-d>
 
-Expect python (generated comments with :param tags):
-  def myFunc(p1: Callable[[int], None] = False, p2: Callable[[int, Exception], None] = {}) -> Sequence[T]:
+Expect python (generated comment with Args tags):
+  def myFunc(p1, p2, p3 = ''):
       """
       TODO
       
       :param p1: TODO
-      :type p1: Callable[[int], None]
+      :type p1: [TODO:type]
       :param p2: TODO
-      :type p2: Callable[[int, Exception], None]
+      :type p2: [TODO:type]
+      :param p3: TODO
+      :type p3: [TODO:type]
+      :return: TODO
+      """
+      pass
+
+# ------------------------------------------------------------------------------
+
+Given python(function with parameters with type hints without return type where b:doge_doc_standard='sphinx'):
+  def myFunc(p1, p2: Callable[[int], None], p3: Callable[[int, Exception], None] = []):
+      pass
+
+Do (trigger doge):
+  :let b:doge_doc_standard='sphinx'\<CR>
+  \<C-d>
+
+Expect python (generated comment with Args tags):
+  def myFunc(p1, p2: Callable[[int], None], p3: Callable[[int, Exception], None] = []):
+      """
+      TODO
+      
+      :param p1: TODO
+      :type p1: [TODO:type]
+      :param p2: TODO
+      :type p2: Callable[[int], None]
+      :param p3: TODO
+      :type p3: Callable[[int, Exception], None]
+      :return: TODO
+      """
+      pass
+
+# ------------------------------------------------------------------------------
+
+Given python(function with parameters with type hints with return type where b:doge_doc_standard='sphinx'):
+  def myFunc(p1, p2: Callable[[int], None], p3: Callable[[int, Exception], None] = []) -> Sequence[T]:
+      pass
+
+Do (trigger doge):
+  :let b:doge_doc_standard='sphinx'\<CR>
+  \<C-d>
+
+Expect python (generated comment with Args and Returns tags):
+  def myFunc(p1, p2: Callable[[int], None], p3: Callable[[int, Exception], None] = []) -> Sequence[T]:
+      """
+      TODO
+      
+      :param p1: TODO
+      :type p1: [TODO:type]
+      :param p2: TODO
+      :type p2: Callable[[int], None]
+      :param p3: TODO
+      :type p3: Callable[[int, Exception], None]
       :return: TODO
       :rtype: Sequence[T]
-      """
-      pass
-
-  def myFunc(p1: Sequence[T], p2: my_module.types) -> Generator[int, float, str]:
-      """
-      TODO
-      
-      :param p1: TODO
-      :type p1: Sequence[T]
-      :param p2: TODO
-      :type p2: my_module.types
-      :return: TODO
-      :rtype: Generator[int, float, str]
-      """
-      pass
-
-# ==============================================================================
-# Functions defined multi-line.
-# ==============================================================================
-Given python (multi-line function with type hint parameters):
-  def myFunc(p1: str, p2: dict,
-          p3: list, p4: tuple) -> Iterator[int]:
-      pass
-
-Do (trigger doge):
-  :let b:doge_doc_standard_python='sphinx'\<CR>
-  \<C-d>
-
-Expect python (generated comment with :param and :rtype tags):
-  def myFunc(p1: str, p2: dict,
-          p3: list, p4: tuple) -> Iterator[int]:
-      """
-      TODO
-      
-      :param p1: TODO
-      :type p1: str
-      :param p2: TODO
-      :type p2: dict
-      :param p3: TODO
-      :type p3: list
-      :param p4: TODO
-      :type p4: tuple
-      :return: TODO
-      :rtype: Iterator[int]
       """
       pass

--- a/test/filetypes/python/functions-doc-sphinx.vader
+++ b/test/filetypes/python/functions-doc-sphinx.vader
@@ -1,7 +1,7 @@
 # ==============================================================================
 # Functions using the Sphinx doc standard.
 # ==============================================================================
-Given python(function without paramters without return type where b:doge_doc_standard='sphinx'):
+Given python(function without parameters without return type where b:doge_doc_standard='sphinx'):
   def myFunc():
       pass
 
@@ -9,7 +9,7 @@ Do (trigger doge):
   :let b:doge_doc_standard='sphinx'\<CR>
   \<C-d>
 
-Expect python (generated comment with nothing but the text 'TODO):
+Expect python (generated comment with nothing but the text 'TODO'):
   def myFunc():
       """
       TODO


### PR DESCRIPTION
# Why this PR?

Following issue #21, this PR changes `reST` documentation format to support `Sphinx` format.
I can move all of this to a new documentation format if needed.

By contributing to DoGe you agree to the following statements:
- [X] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [X] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).