### PR TITLE
Add the `:DogeGenerate` command to generate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ on a function, press `<Leader>d`, jump quickly through `TODO` items using
     + [`g:doge_mapping_comment_jump_backward`](#gdoge_mapping_comment_jump_backward)
     + [`g:doge_comment_interactive`](#gdoge_comment_interactive)
 - [Commands](#commands)
-  * [`:DogeGenerate`](#dogegenerate)
+    + [`:DogeGenerate`](#dogegenerate)
 - [Help](#help)
 - [FAQ](#faq)
     + [Jump-forward trigger requires to be pressed 2 times in order to jump forward](#jump-forward-trigger-requires-to-be-pressed-2-times-in-order-to-jump-forward)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ on a function, press `<Leader>d`, jump quickly through `TODO` items using
     + [`g:doge_mapping_comment_jump_forward`](#gdoge_mapping_comment_jump_forward)
     + [`g:doge_mapping_comment_jump_backward`](#gdoge_mapping_comment_jump_backward)
     + [`g:doge_comment_interactive`](#gdoge_comment_interactive)
+- [Commands](#commands)
+  * [`:DogeGenerate`](#dogegenerate)
 - [Help](#help)
 - [FAQ](#faq)
     + [Jump-forward trigger requires to be pressed 2 times in order to jump forward](#jump-forward-trigger-requires-to-be-pressed-2-times-in-order-to-jump-forward)
@@ -153,6 +155,12 @@ The mapping to jump backward to the next `TODO` item in a comment. Requires
 Default: `1`
 
 Jumps interactively through all `TODO` items in the generated comment.
+
+# Commands
+
+### `:DogeGenerate`
+
+Command to generate documentation.
 
 # Help
 

--- a/autoload/doge/generate.vim
+++ b/autoload/doge/generate.vim
@@ -151,7 +151,7 @@ function! doge#generate#pattern(pattern) abort
         " Go to the top of the comment and select the first TODO.
         exe l:comment_lnum_insert_position + 1
         call search(s:comment_placeholder, 'W')
-        execute("normal! gno\<C-g>")
+        call execute("normal! gno\<C-g>")
       endif
     endif
   endif

--- a/autoload/doge/helpers.vim
+++ b/autoload/doge/helpers.vim
@@ -23,6 +23,7 @@ function! doge#helpers#count(word, ...) abort
       let l:range = printf('%s,%s', a:2, a:1)
     endif
   endif
+
   try
     let l:cnt = execute(l:range . 's/' . a:word . '//gn')
   catch /^Vim\%((\a\+)\)\=:E486/

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -7,6 +7,7 @@ CONTENTS                                                       *doge-contents*
   2. Configuration...............................................|doge-config|
   3. Functions................................................|doge-functions|
       1. Preprocessors....................................|doge-preprocessors|
+  4. Commands..................................................|doge-commands|
 
 ==============================================================================
 INTRODUCTION                                                      *doge-intro*
@@ -118,5 +119,10 @@ a comment. The following preprocess functions are available:
 
   doge#preprocessors#<filetype>#insert_position(lnum_insert_pos)
 
+==============================================================================
+COMMANDS                                                       *doge-commands*
+
+:DogeGererate                                                  *:DogeGenerate*
+  Command to generate documentation.
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -5,9 +5,9 @@ Kim Koomen                                                              *doge*
 CONTENTS                                                       *doge-contents*
   1. Introduction.................................................|doge-intro|
   2. Configuration...............................................|doge-config|
-  3. Functions................................................|doge-functions|
+  3. Commands..................................................|doge-commands|
+  4. Functions................................................|doge-functions|
       1. Preprocessors....................................|doge-preprocessors|
-  4. Commands..................................................|doge-commands|
 
 ==============================================================================
 INTRODUCTION                                                      *doge-intro*
@@ -45,6 +45,12 @@ The mapping to jump backward to the previous TODO item in a comment. Requires
 (Default: 1)
 
 Jumps interactively through all TODO items in the generated comment.
+
+==============================================================================
+COMMANDS                                                       *doge-commands*
+
+:DogeGenerate                                                  *:DogeGenerate*
+  Command to generate documentation.
 
 ==============================================================================
 FUNCTIONS                                                     *doge-functions*
@@ -119,10 +125,5 @@ a comment. The following preprocess functions are available:
 
   doge#preprocessors#<filetype>#insert_position(lnum_insert_pos)
 
-==============================================================================
-COMMANDS                                                       *doge-commands*
-
-:DogeGererate                                                  *:DogeGenerate*
-  Command to generate documentation.
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/doc/tags
+++ b/doc/tags
@@ -1,3 +1,4 @@
+:DogeGenerate	doge.txt	/*:DogeGenerate*
 doge	doge.txt	/*doge*
 doge#comment#jump()	doge.txt	/*doge#comment#jump()*
 doge#comment#update_interactive_comment_info()	doge.txt	/*doge#comment#update_interactive_comment_info()*
@@ -9,6 +10,7 @@ doge#helpers#placeholder()	doge.txt	/*doge#helpers#placeholder()*
 doge#indent#add()	doge.txt	/*doge#indent#add()*
 doge#token#extract()	doge.txt	/*doge#token#extract()*
 doge#token#replace()	doge.txt	/*doge#token#replace()*
+doge-commands	doge.txt	/*doge-commands*
 doge-config	doge.txt	/*doge-config*
 doge-contents	doge.txt	/*doge-contents*
 doge-functions	doge.txt	/*doge-functions*

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -79,8 +79,6 @@ if !exists('g:doge_comment_interactive')
   let g:doge_comment_interactive = 1
 endif
 
-command! -nargs=0 DogeGenerate call doge#generate()
-
 nnoremap <Plug>(doge-generate) :call doge#generate()<CR>
 nnoremap <expr> <Plug>(doge-comment-jump-forward) doge#comment#jump('forward')
 nnoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump('backward')
@@ -96,6 +94,10 @@ execute(printf('imap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapp
 execute(printf('imap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
 execute(printf('smap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
 execute(printf('smap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+
+""
+" Command to generate documentation.
+command! -nargs=0 DogeGenerate normal <Plug>(doge-generate)
 
 augroup doge
   autocmd!

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -97,7 +97,7 @@ execute(printf('smap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_map
 
 ""
 " Command to generate documentation.
-command! -nargs=0 DogeGenerate normal <Plug>(doge-generate)
+command! -nargs=0 DogeGenerate call doge#generate()
 
 augroup doge
   autocmd!

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -79,6 +79,8 @@ if !exists('g:doge_comment_interactive')
   let g:doge_comment_interactive = 1
 endif
 
+command! -nargs=0 DogeGenerate call doge#generate()
+
 nnoremap <Plug>(doge-generate) :call doge#generate()<CR>
 nnoremap <expr> <Plug>(doge-comment-jump-forward) doge#comment#jump('forward')
 nnoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump('backward')


### PR DESCRIPTION
# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

This just adds a command – `:DogeGenerate` – to generate documentation.

_**Note:** The `vimdoc` command did not add anything to the help file, so I took the initiative to add a section manually. I can remove it if necessary._
