### PR TITLE
Add a configurable setting to enable or disable mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ on a function, press `<Leader>d`, jump quickly through `TODO` items using
 - [Configuration](#configuration)
   * [Choosing a different doc standard](#choosing-a-different-doc-standard)
   * [Options](#options)
+    + [`g:doge_enable_mappings`](#gdoge_enable_mappings)
     + [`g:doge_mapping`](#gdoge_mapping)
     + [`g:doge_mapping_comment_jump_forward`](#gdoge_mapping_comment_jump_forward)
     + [`g:doge_mapping_comment_jump_backward`](#gdoge_mapping_comment_jump_backward)
@@ -127,6 +128,12 @@ Here is the full list of available doc standards per filetype:
 | `g:doge_doc_standard_cpp`          | `'doxygen'`  | `'doxygen'`                                 |
 
 ## Options
+
+### `g:doge_enable_mappings`
+
+Default: `1`
+
+Whether or not to enable builtin mappings.
 
 ### `g:doge_mapping`
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Here is the full list of available doc standards per filetype:
 
 Default: `1`
 
-Whether or not to enable builtin mappings.
+Whether or not to enable built-in mappings.
 
 ### `g:doge_mapping`
 

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -27,7 +27,7 @@ CONFIGURATION                                                    *doge-config*
                                                       *g:doge_enable_mappings*
 (Default: 1)
 
-Whether or not to enable builtin mappings.
+Whether or not to enable built-in mappings.
 
                                                               *g:doge_mapping*
 (Default: '<Leader>d')

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -23,6 +23,11 @@ coding!
 ==============================================================================
 CONFIGURATION                                                    *doge-config*
 
+                                                      *g:doge_enable_mappings*
+(Default: 1)
+
+Whether or not to enable builtin mappings.
+
                                                               *g:doge_mapping*
 (Default: '<Leader>d')
 

--- a/doc/tags
+++ b/doc/tags
@@ -18,6 +18,7 @@ doge-intro	doge.txt	/*doge-intro*
 doge-preprocessors	doge.txt	/*doge-preprocessors*
 doge.txt	doge.txt	/*doge.txt*
 g:doge_comment_interactive	doge.txt	/*g:doge_comment_interactive*
+g:doge_enable_mappings	doge.txt	/*g:doge_enable_mappings*
 g:doge_mapping	doge.txt	/*g:doge_mapping*
 g:doge_mapping_comment_jump_backward	doge.txt	/*g:doge_mapping_comment_jump_backward*
 g:doge_mapping_comment_jump_forward	doge.txt	/*g:doge_mapping_comment_jump_forward*

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -42,7 +42,7 @@ call add(b:doge_patterns, {
 \  'match': '\m^def\s\+\%([^(]\+\)\s*(\(.\{-}\))\%(\s*->\s*\(.\{-}\)\)\?\s*:',
 \  'match_group_names': ['parameters', 'returnType'],
 \  'parameters': {
-\    'match': '\m\([[:alnum:]_]\+\)\%(:\s*\([[:alnum:]_.]\+\%(\[[[:alnum:]_[\],[:space:]]*\]\)\?\)\)\?\%(\s*=\s*\([^,]\+\)\)\?',
+\    'match': '\m\([[:alnum:]_]\+\)\%(\s*:\s*\([[:alnum:]_.]\+\%(\[[[:alnum:]_[\],[:space:]]*\]\)\?\)\)\?\%(\s*=\s*\([^,]\+\)\)\?',
 \    'match_group_names': ['name', 'type', 'default'],
 \    'format': {
 \      'reST': ':param {name} {type|!type}: !description',

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -45,6 +45,14 @@ if exists('g:loaded_doge')
 endif
 let g:loaded_doge = 1
 
+if !exists('g:doge_enable_mappings')
+  ""
+  " (Default: 1)
+  "
+  " Whether or not to enable builtin mappings.
+  let g:doge_enable_mappings = 1
+endif
+
 if !exists('g:doge_mapping')
   ""
   " (Default: '<Leader>d')
@@ -87,13 +95,15 @@ inoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump('backward')
 snoremap <expr> <Plug>(doge-comment-jump-forward) doge#comment#jump('forward')
 snoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump('backward')
 
-execute(printf('nmap <silent> %s <Plug>(doge-generate)', g:doge_mapping))
-execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
-execute(printf('imap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-execute(printf('imap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
-execute(printf('smap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-execute(printf('smap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+if g:doge_enable_mappings == v:true
+  execute(printf('nmap <silent> %s <Plug>(doge-generate)', g:doge_mapping))
+  execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
+  execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+  execute(printf('imap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
+  execute(printf('imap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+  execute(printf('smap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
+  execute(printf('smap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+endif
 
 augroup doge
   autocmd!

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -49,7 +49,7 @@ if !exists('g:doge_enable_mappings')
   ""
   " (Default: 1)
   "
-  " Whether or not to enable builtin mappings.
+  " Whether or not to enable built-in mappings.
   let g:doge_enable_mappings = 1
 endif
 


### PR DESCRIPTION
# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

This adds a new configurable setting – `g:doge_enable_mappings` – to enable or disable mappings.

Its value is set to `1` by default, so all mappings will be added (as is the case right now).

If set to `0`, then no mappings will be added, but the "plugin" mappings (ie: `<Plug>(doge-generate)`) will still be declared.
