### PR TITLE
Use buffer mappings

### DIFF
--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -5,13 +5,64 @@ set cpoptions&vim
 " @public
 " Generates documentation based on available patterns in b:doge_patterns.
 function! doge#generate() abort
+  if exists('b:doge_interactive')
+    return doge#deactivate()
+  endif
+  let success = 0
   if exists('b:doge_patterns')
     for l:pattern in get(b:, 'doge_patterns')
       if doge#generate#pattern(l:pattern) == v:false
         continue
+      else
+        let success = 1
       endif
-      return 1
+      if success
+        call doge#activate()
+      endif
+      return success
     endfor
+  endif
+endfunction
+
+""
+" @public
+" Activate doge mappings
+function! doge#activate() abort
+  let [f, b] = [g:doge_mapping_comment_jump_forward, g:doge_mapping_comment_jump_backward]
+  execute 'nmap <nowait><silent><buffer>' f '<Plug>(doge-comment-jump-forward)'
+  execute 'nmap <nowait><silent><buffer>' b '<Plug>(doge-comment-jump-backward)'
+  execute 'imap <nowait><silent><buffer>' f '<Plug>(doge-comment-jump-forward)'
+  execute 'imap <nowait><silent><buffer>' b '<Plug>(doge-comment-jump-backward)'
+  execute 'smap <nowait><silent><buffer>' f '<Plug>(doge-comment-jump-forward)'
+  execute 'smap <nowait><silent><buffer>' b '<Plug>(doge-comment-jump-backward)'
+  if get(g:, 'doge_activation_message', 1)
+    echo '[vim-doge] '
+    echohl Label
+    echon 'activated'
+    echohl None
+  endif
+endfunction
+
+""
+" @public
+" Deactivate doge mappings and unlet buffer variable.
+" Can print a message with the reason of deactivation/termination.
+function! doge#deactivate(...) abort
+  unlet b:doge_interactive
+  execute 'nunmap <buffer>' g:doge_mapping_comment_jump_forward
+  execute 'nunmap <buffer>' g:doge_mapping_comment_jump_backward
+  execute 'iunmap <buffer>' g:doge_mapping_comment_jump_forward
+  execute 'iunmap <buffer>' g:doge_mapping_comment_jump_backward
+  execute 'sunmap <buffer>' g:doge_mapping_comment_jump_forward
+  execute 'sunmap <buffer>' g:doge_mapping_comment_jump_backward
+  if get(g:, 'doge_deactivation_message', 1)
+    echo '[vim-doge] '
+    echohl WarningMsg
+    echon 'deactivated'
+    echohl None
+    if a:0
+      echon ': ' a:1
+    endif
   endif
 endfunction
 

--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -5,9 +5,6 @@ set cpoptions&vim
 " @public
 " Generates documentation based on available patterns in b:doge_patterns.
 function! doge#generate() abort
-  if exists('b:doge_interactive')
-    return doge#deactivate()
-  endif
   let success = v:false
   if exists('b:doge_patterns')
     for l:pattern in get(b:, 'doge_patterns')

--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -8,13 +8,13 @@ function! doge#generate() abort
   if exists('b:doge_interactive')
     return doge#deactivate()
   endif
-  let success = 0
+  let success = v:false
   if exists('b:doge_patterns')
     for l:pattern in get(b:, 'doge_patterns')
       if doge#generate#pattern(l:pattern) == v:false
         continue
       else
-        let success = 1
+        let success = v:true
       endif
       if success
         call doge#activate()
@@ -28,6 +28,9 @@ endfunction
 " @public
 " Activate doge mappings
 function! doge#activate() abort
+  if !get(g:, 'doge_comment_interactive', 1)
+    return
+  endif
   let [f, b] = [g:doge_mapping_comment_jump_forward, g:doge_mapping_comment_jump_backward]
   execute 'nmap <nowait><silent><buffer>' f '<Plug>(doge-comment-jump-forward)'
   execute 'nmap <nowait><silent><buffer>' b '<Plug>(doge-comment-jump-backward)'
@@ -49,6 +52,9 @@ endfunction
 " Can print a message with the reason of deactivation/termination.
 function! doge#deactivate(...) abort
   unlet b:doge_interactive
+  if !get(g:, 'doge_comment_interactive', 1)
+    return
+  endif
   execute 'nunmap <buffer>' g:doge_mapping_comment_jump_forward
   execute 'nunmap <buffer>' g:doge_mapping_comment_jump_backward
   execute 'iunmap <buffer>' g:doge_mapping_comment_jump_forward

--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -36,7 +36,7 @@ function! doge#activate() abort
   execute 'smap <nowait><silent><buffer>' f '<Plug>(doge-comment-jump-forward)'
   execute 'smap <nowait><silent><buffer>' b '<Plug>(doge-comment-jump-backward)'
   if get(g:, 'doge_activation_message', 0)
-    echo '[vim-doge] '
+    echo '[DoGe] '
     echohl Label
     echon 'activated'
     echohl None
@@ -59,7 +59,7 @@ function! doge#deactivate(...) abort
   execute 'sunmap <buffer>' g:doge_mapping_comment_jump_forward
   execute 'sunmap <buffer>' g:doge_mapping_comment_jump_backward
   if get(g:, 'doge_deactivation_message', 0)
-    echo '[vim-doge] '
+    echo '[DoGe] '
     echohl WarningMsg
     echon 'deactivated'
     echohl None

--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -5,18 +5,18 @@ set cpoptions&vim
 " @public
 " Generates documentation based on available patterns in b:doge_patterns.
 function! doge#generate() abort
-  let success = v:false
+  let l:success = v:false
   if exists('b:doge_patterns')
     for l:pattern in get(b:, 'doge_patterns')
       if doge#generate#pattern(l:pattern) == v:false
         continue
       else
-        let success = v:true
+        let l:success = v:true
       endif
-      if success
+      if l:success
         call doge#activate()
       endif
-      return success
+      return l:success
     endfor
   endif
 endfunction
@@ -28,13 +28,13 @@ function! doge#activate() abort
   if !get(g:, 'doge_comment_interactive', 1) || !get(g:, 'doge_buffer_mappings', 0)
     return
   endif
-  let [f, b] = [g:doge_mapping_comment_jump_forward, g:doge_mapping_comment_jump_backward]
-  execute 'nmap <nowait><silent><buffer>' f '<Plug>(doge-comment-jump-forward)'
-  execute 'nmap <nowait><silent><buffer>' b '<Plug>(doge-comment-jump-backward)'
-  execute 'imap <nowait><silent><buffer>' f '<Plug>(doge-comment-jump-forward)'
-  execute 'imap <nowait><silent><buffer>' b '<Plug>(doge-comment-jump-backward)'
-  execute 'smap <nowait><silent><buffer>' f '<Plug>(doge-comment-jump-forward)'
-  execute 'smap <nowait><silent><buffer>' b '<Plug>(doge-comment-jump-backward)'
+  let [l:f, l:b] = [g:doge_mapping_comment_jump_forward, g:doge_mapping_comment_jump_backward]
+  execute 'nmap <nowait><silent><buffer>' l:f '<Plug>(doge-comment-jump-forward)'
+  execute 'nmap <nowait><silent><buffer>' l:b '<Plug>(doge-comment-jump-backward)'
+  execute 'imap <nowait><silent><buffer>' l:f '<Plug>(doge-comment-jump-forward)'
+  execute 'imap <nowait><silent><buffer>' l:b '<Plug>(doge-comment-jump-backward)'
+  execute 'smap <nowait><silent><buffer>' l:f '<Plug>(doge-comment-jump-forward)'
+  execute 'smap <nowait><silent><buffer>' l:b '<Plug>(doge-comment-jump-backward)'
   if get(g:, 'doge_activation_message', 0)
     echo '[DoGe] '
     echohl Label

--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -25,7 +25,7 @@ endfunction
 " @public
 " Activate doge mappings
 function! doge#activate() abort
-  if !get(g:, 'doge_comment_interactive', 1)
+  if !get(g:, 'doge_comment_interactive', 1) || !get(g:, 'doge_buffer_mappings', 0)
     return
   endif
   let [f, b] = [g:doge_mapping_comment_jump_forward, g:doge_mapping_comment_jump_backward]
@@ -35,7 +35,7 @@ function! doge#activate() abort
   execute 'imap <nowait><silent><buffer>' b '<Plug>(doge-comment-jump-backward)'
   execute 'smap <nowait><silent><buffer>' f '<Plug>(doge-comment-jump-forward)'
   execute 'smap <nowait><silent><buffer>' b '<Plug>(doge-comment-jump-backward)'
-  if get(g:, 'doge_activation_message', 1)
+  if get(g:, 'doge_activation_message', 0)
     echo '[vim-doge] '
     echohl Label
     echon 'activated'
@@ -49,7 +49,7 @@ endfunction
 " Can print a message with the reason of deactivation/termination.
 function! doge#deactivate(...) abort
   unlet b:doge_interactive
-  if !get(g:, 'doge_comment_interactive', 1)
+  if !get(g:, 'doge_comment_interactive', 1) || !get(g:, 'doge_buffer_mappings', 0)
     return
   endif
   execute 'nunmap <buffer>' g:doge_mapping_comment_jump_forward
@@ -58,7 +58,7 @@ function! doge#deactivate(...) abort
   execute 'iunmap <buffer>' g:doge_mapping_comment_jump_backward
   execute 'sunmap <buffer>' g:doge_mapping_comment_jump_forward
   execute 'sunmap <buffer>' g:doge_mapping_comment_jump_backward
-  if get(g:, 'doge_deactivation_message', 1)
+  if get(g:, 'doge_deactivation_message', 0)
     echo '[vim-doge] '
     echohl WarningMsg
     echon 'deactivated'

--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -79,10 +79,19 @@ function! doge#comment#jump(direction) abort
 
       if l:jump_keyseq != v:false
         if l:todo_count == 1
-          " Last placeholder reached
+          " One placeholder left
           call doge#deactivate('reached last placeholder')
         endif
         return l:jump_keyseq
+      elseif a:direction == 'forward'
+        " Last placeholder, go forward to first
+        exe b:doge_interactive['lnum_comment_start_pos']
+        return doge#comment#jump('forward')
+      elseif a:direction == 'backward'
+        " First placeholder, go back to last
+        let l = b:doge_interactive['lnum_comment_end_pos']
+        call cursor(l, col([l, '$']))
+        return doge#comment#jump('backward')
       endif
     else
       " All the TODO items have been resolved, so we're done.

--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -60,7 +60,7 @@ function! doge#comment#jump(direction) abort
   if exists('b:doge_interactive')
     " Quit interactive mode if the cursor is outside of the comment.
     if line('.') < b:doge_interactive['lnum_comment_start_pos'] || line('.') > b:doge_interactive['lnum_comment_end_pos']
-      unlet b:doge_interactive
+      call doge#deactivate('outside of comment area')
       return l:regular_mapping
     endif
 
@@ -76,12 +76,17 @@ function! doge#comment#jump(direction) abort
       call doge#comment#update_interactive_comment_info()
 
       let l:jump_keyseq = call(printf('s:jump_%s', a:direction), [])
+
       if l:jump_keyseq != v:false
+        if l:todo_count == 1
+          " Last placeholder reached
+          call doge#deactivate('reached last placeholder')
+        endif
         return l:jump_keyseq
       endif
     else
       " All the TODO items have been resolved, so we're done.
-      unlet b:doge_interactive
+      call doge#deactivate('end of placeholders')
     endif
   endif
 

--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -77,18 +77,30 @@ function! doge#comment#jump(direction) abort
 
       let l:jump_keyseq = call(printf('s:jump_%s', a:direction), [])
 
-      if l:jump_keyseq != v:false
+      " If buffer mappings are used, we deactivate them as soon as the last
+      " placeholder is reached. Moreover we keep cycling placeholders when
+      " pressing <Tab>, as long as there is more than one left.
+      " NOTE: this is not default behaviour otherwise, because of failing tests.
+
+      if !g:doge_buffer_mappings
+        if l:jump_keyseq != v:false
+          return l:jump_keyseq
+        endif
+
+      elseif l:jump_keyseq != v:false
         if l:todo_count == 1
           " One placeholder left
           call doge#deactivate('reached last placeholder')
         endif
         return l:jump_keyseq
+
       elseif a:direction == 'forward'
-        " Last placeholder, go forward to first
+        " Last placeholder, go to first
         exe b:doge_interactive['lnum_comment_start_pos']
         return doge#comment#jump('forward')
+
       elseif a:direction == 'backward'
-        " First placeholder, go back to last
+        " First placeholder, go to last
         let l = b:doge_interactive['lnum_comment_end_pos']
         call cursor(l, col([l, '$']))
         return doge#comment#jump('backward')

--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -94,15 +94,15 @@ function! doge#comment#jump(direction) abort
         endif
         return l:jump_keyseq
 
-      elseif a:direction == 'forward'
+      elseif a:direction ==# 'forward'
         " Last placeholder, go to first
         exe b:doge_interactive['lnum_comment_start_pos']
         return doge#comment#jump('forward')
 
-      elseif a:direction == 'backward'
+      elseif a:direction ==# 'backward'
         " First placeholder, go to last
-        let l = b:doge_interactive['lnum_comment_end_pos']
-        call cursor(l, col([l, '$']))
+        let l:line = b:doge_interactive['lnum_comment_end_pos']
+        call cursor(l:line, col([l:line, '$']))
         return doge#comment#jump('backward')
       endif
     else

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -51,6 +51,12 @@ The mapping to jump backward to the previous TODO item in a comment. Requires
 
 Jumps interactively through all TODO items in the generated comment.
 
+                                                       *g:doge_buffer_mappings*
+(Default: 0)
+
+Mappings to jump forward/backward are applied as buffer mappings when
+interactive mode starts, and removed when it ends.
+
 ==============================================================================
 COMMANDS                                                       *doge-commands*
 

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -104,12 +104,6 @@ snoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump('backward')
 
 if g:doge_enable_mappings == v:true
   execute(printf('nmap <silent> %s <Plug>(doge-generate)', g:doge_mapping))
-  execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-  execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
-  execute(printf('imap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-  execute(printf('imap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
-  execute(printf('smap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-  execute(printf('smap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
 endif
 
 ""

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -68,6 +68,15 @@ if !exists('g:doge_mapping')
   let g:doge_mapping = '<Leader>d'
 endif
 
+if !exists('g:doge_buffer_mappings')
+  ""
+  " (Default: 0)
+  "
+  " Mappings to jump forward/backward are applied as buffer mappings when
+  " interactive mode starts, and removed when it ends.
+  let g:doge_buffer_mappings = 0
+endif
+
 if !exists('g:doge_mapping_comment_jump_forward')
   ""
   " (Default: '<Tab>')
@@ -104,6 +113,14 @@ snoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump('backward')
 
 if g:doge_enable_mappings == v:true
   execute(printf('nmap <silent> %s <Plug>(doge-generate)', g:doge_mapping))
+  if !g:doge_buffer_mappings
+    execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
+    execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+    execute(printf('imap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
+    execute(printf('imap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+    execute(printf('smap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
+    execute(printf('smap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+  endif
 endif
 
 ""


### PR DESCRIPTION
# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [ x] I have ~read and understood~ currently no time for the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [ x] I have ~read and understood~ currently no time for the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

`<Tab>` and `<S-Tab>` are the most obvious mappings, but to dedicate them to
doge (and in all modes) is very demanding. Use buffer mappings instead,
so that they are only active in 'doge-mode', and unmapped when finished.

Deactivation is either automatic (end of placeholders, press outside of
comment area) or manual (main mapping is pressed again).

The first commit didn't give me troubles. The second commit requires some testing (I had a recursion once, then I changed it and it looks ok but some more testing is needed).