### PR TITLE
g:doge_buffer_mappings (default 0)

### DIFF
--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -5,13 +5,67 @@ set cpoptions&vim
 " @public
 " Generates documentation based on available patterns in b:doge_patterns.
 function! doge#generate() abort
+  let l:success = v:false
   if exists('b:doge_patterns')
     for l:pattern in get(b:, 'doge_patterns')
       if doge#generate#pattern(l:pattern) == v:false
         continue
+      else
+        let l:success = v:true
       endif
-      return 1
+      if l:success
+        call doge#activate()
+      endif
+      return l:success
     endfor
+  endif
+endfunction
+
+""
+" @public
+" Activate doge buffer mappings, if option is set.
+function! doge#activate() abort
+  if !g:doge_comment_interactive || !g:doge_buffer_mappings
+    return
+  endif
+  let [l:f, l:b] = [g:doge_mapping_comment_jump_forward, g:doge_mapping_comment_jump_backward]
+  execute 'nmap <nowait><silent><buffer>' l:f '<Plug>(doge-comment-jump-forward)'
+  execute 'nmap <nowait><silent><buffer>' l:b '<Plug>(doge-comment-jump-backward)'
+  execute 'imap <nowait><silent><buffer>' l:f '<Plug>(doge-comment-jump-forward)'
+  execute 'imap <nowait><silent><buffer>' l:b '<Plug>(doge-comment-jump-backward)'
+  execute 'smap <nowait><silent><buffer>' l:f '<Plug>(doge-comment-jump-forward)'
+  execute 'smap <nowait><silent><buffer>' l:b '<Plug>(doge-comment-jump-backward)'
+  if get(g:, 'doge_activation_message', 0)
+    echo '[DoGe] '
+    echohl Label
+    echon 'activated'
+    echohl None
+  endif
+endfunction
+
+""
+" @public
+" Deactivate doge mappings and unlet buffer variable.
+" Can print a message with the reason of deactivation/termination.
+function! doge#deactivate(...) abort
+  unlet b:doge_interactive
+  if !g:doge_comment_interactive || !g:doge_buffer_mappings
+    return
+  endif
+  execute 'nunmap <buffer>' g:doge_mapping_comment_jump_forward
+  execute 'nunmap <buffer>' g:doge_mapping_comment_jump_backward
+  execute 'iunmap <buffer>' g:doge_mapping_comment_jump_forward
+  execute 'iunmap <buffer>' g:doge_mapping_comment_jump_backward
+  execute 'sunmap <buffer>' g:doge_mapping_comment_jump_forward
+  execute 'sunmap <buffer>' g:doge_mapping_comment_jump_backward
+  if get(g:, 'doge_deactivation_message', 0)
+    echo '[DoGe] '
+    echohl WarningMsg
+    echon 'deactivated'
+    echohl None
+    if a:0
+      echon ': ' a:1
+    endif
   endif
 endfunction
 

--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -5,7 +5,7 @@ set cpoptions&vim
 " @public
 " Generates documentation based on available patterns in b:doge_patterns.
 function! doge#generate() abort
-  let l:success = v:false
+  let l:success = 0
   if exists('b:doge_patterns')
     for l:pattern in get(b:, 'doge_patterns')
       if doge#generate#pattern(l:pattern) == v:false
@@ -13,7 +13,7 @@ function! doge#generate() abort
       else
         let l:success = v:true
       endif
-      if l:success
+      if l:success == v:true
         call doge#activate()
       endif
       return l:success
@@ -25,48 +25,39 @@ endfunction
 " @public
 " Activate doge buffer mappings, if option is set.
 function! doge#activate() abort
-  if !g:doge_comment_interactive || !g:doge_buffer_mappings
+  if g:doge_comment_interactive == v:false || g:doge_buffer_mappings == v:false
     return
   endif
-  let [l:f, l:b] = [g:doge_mapping_comment_jump_forward, g:doge_mapping_comment_jump_backward]
-  execute 'nmap <nowait><silent><buffer>' l:f '<Plug>(doge-comment-jump-forward)'
-  execute 'nmap <nowait><silent><buffer>' l:b '<Plug>(doge-comment-jump-backward)'
-  execute 'imap <nowait><silent><buffer>' l:f '<Plug>(doge-comment-jump-forward)'
-  execute 'imap <nowait><silent><buffer>' l:b '<Plug>(doge-comment-jump-backward)'
-  execute 'smap <nowait><silent><buffer>' l:f '<Plug>(doge-comment-jump-forward)'
-  execute 'smap <nowait><silent><buffer>' l:b '<Plug>(doge-comment-jump-backward)'
-  if get(g:, 'doge_activation_message', 0)
-    echo '[DoGe] '
-    echohl Label
-    echon 'activated'
-    echohl None
-  endif
+
+  let [l:f, l:b] = [
+        \ g:doge_mapping_comment_jump_forward,
+        \ g:doge_mapping_comment_jump_backward,
+        \ ]
+  for l:mode in ['n', 'i', 's']
+    execute(printf('%smap <nowait> <silent> <buffer> %s <Plug>(doge-comment-jump-forward)', l:mode, l:f))
+    execute(printf('%smap <nowait> <silent> <buffer> %s <Plug>(doge-comment-jump-backward)', l:mode, l:b))
+  endfor
 endfunction
 
 ""
 " @public
 " Deactivate doge mappings and unlet buffer variable.
 " Can print a message with the reason of deactivation/termination.
-function! doge#deactivate(...) abort
+function! doge#deactivate() abort
   unlet b:doge_interactive
-  if !g:doge_comment_interactive || !g:doge_buffer_mappings
+
+  if g:doge_comment_interactive == v:false || g:doge_buffer_mappings == v:false
     return
   endif
-  execute 'nunmap <buffer>' g:doge_mapping_comment_jump_forward
-  execute 'nunmap <buffer>' g:doge_mapping_comment_jump_backward
-  execute 'iunmap <buffer>' g:doge_mapping_comment_jump_forward
-  execute 'iunmap <buffer>' g:doge_mapping_comment_jump_backward
-  execute 'sunmap <buffer>' g:doge_mapping_comment_jump_forward
-  execute 'sunmap <buffer>' g:doge_mapping_comment_jump_backward
-  if get(g:, 'doge_deactivation_message', 0)
-    echo '[DoGe] '
-    echohl WarningMsg
-    echon 'deactivated'
-    echohl None
-    if a:0
-      echon ': ' a:1
-    endif
-  endif
+
+  let [l:f, l:b] = [
+        \ g:doge_mapping_comment_jump_forward,
+        \ g:doge_mapping_comment_jump_backward,
+        \ ]
+  for l:mode in ['n', 'i', 's']
+    execute(printf('%sunmap <buffer> %s', l:mode, l:f))
+    execute(printf('%sunmap <buffer> %s', l:mode, l:b))
+  endfor
 endfunction
 
 let &cpoptions = s:save_cpo

--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -60,7 +60,7 @@ function! doge#comment#jump(direction) abort
   if exists('b:doge_interactive')
     " Quit interactive mode if the cursor is outside of the comment.
     if line('.') < b:doge_interactive['lnum_comment_start_pos'] || line('.') > b:doge_interactive['lnum_comment_end_pos']
-      unlet b:doge_interactive
+      call doge#deactivate('outside of comment area')
       return l:regular_mapping
     endif
 
@@ -81,7 +81,7 @@ function! doge#comment#jump(direction) abort
       endif
     else
       " All the TODO items have been resolved, so we're done.
-      unlet b:doge_interactive
+      call doge#deactivate('end of placeholders')
     endif
   endif
 

--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -60,7 +60,7 @@ function! doge#comment#jump(direction) abort
   if exists('b:doge_interactive')
     " Quit interactive mode if the cursor is outside of the comment.
     if line('.') < b:doge_interactive['lnum_comment_start_pos'] || line('.') > b:doge_interactive['lnum_comment_end_pos']
-      call doge#deactivate('outside of comment area')
+      call doge#deactivate()
       return l:regular_mapping
     endif
 
@@ -81,7 +81,7 @@ function! doge#comment#jump(direction) abort
       endif
     else
       " All the TODO items have been resolved, so we're done.
-      call doge#deactivate('end of placeholders')
+      call doge#deactivate()
     endif
   endif
 

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -34,6 +34,12 @@ Whether or not to enable built-in mappings.
 
 The mapping to trigger DoGe.
 
+                                                      *g:doge_buffer_mappings*
+(Default: 1)
+
+Mappings to jump forward/backward are applied as buffer mappings when
+interactive mode starts, and removed when it ends.
+
                                          *g:doge_mapping_comment_jump_forward*
 (Default: '<Tab>')
 
@@ -51,12 +57,6 @@ The mapping to jump backward to the previous TODO item in a comment. Requires
 
 Jumps interactively through all TODO items in the generated comment.
 
-                                                      *g:doge_buffer_mappings*
-(Default: 1)
-
-Mappings to jump forward/backward are applied as buffer mappings when
-interactive mode starts, and removed when it ends.
-
 ==============================================================================
 COMMANDS                                                       *doge-commands*
 
@@ -68,6 +68,13 @@ FUNCTIONS                                                     *doge-functions*
 
 doge#generate()                                              *doge#generate()*
   Generates documentation based on available patterns in b:doge_patterns.
+
+doge#activate()                                              *doge#activate()*
+  Activate doge buffer mappings, if option is set.
+
+doge#deactivate()                                          *doge#deactivate()*
+  Deactivate doge mappings and unlet buffer variable. Can print a message with
+  the reason of deactivation/termination.
 
 doge#comment#jump({direction})                           *doge#comment#jump()*
   Jumps to the previous and next TODO item in the comment based on the

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -51,7 +51,7 @@ The mapping to jump backward to the previous TODO item in a comment. Requires
 
 Jumps interactively through all TODO items in the generated comment.
 
-                                                       *g:doge_buffer_mappings*
+                                                      *g:doge_buffer_mappings*
 (Default: 0)
 
 Mappings to jump forward/backward are applied as buffer mappings when

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -52,7 +52,7 @@ The mapping to jump backward to the previous TODO item in a comment. Requires
 Jumps interactively through all TODO items in the generated comment.
 
                                                       *g:doge_buffer_mappings*
-(Default: 0)
+(Default: 1)
 
 Mappings to jump forward/backward are applied as buffer mappings when
 interactive mode starts, and removed when it ends.

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -51,6 +51,12 @@ The mapping to jump backward to the previous TODO item in a comment. Requires
 
 Jumps interactively through all TODO items in the generated comment.
 
+                                                       *g:doge_buffer_mappings*
+(Default: 0)
+
+Mappings to jump forward/backward are applied as buffer mappings when
+interactive mode starts, and removed when it ends.
+
 ==============================================================================
 COMMANDS                                                       *doge-commands*
 

--- a/doc/tags
+++ b/doc/tags
@@ -1,12 +1,15 @@
 :DogeGenerate	doge.txt	/*:DogeGenerate*
 doge	doge.txt	/*doge*
+doge#activate()	doge.txt	/*doge#activate()*
 doge#comment#jump()	doge.txt	/*doge#comment#jump()*
 doge#comment#update_interactive_comment_info()	doge.txt	/*doge#comment#update_interactive_comment_info()*
+doge#deactivate()	doge.txt	/*doge#deactivate()*
 doge#generate#pattern()	doge.txt	/*doge#generate#pattern()*
 doge#generate()	doge.txt	/*doge#generate()*
 doge#helpers#count()	doge.txt	/*doge#helpers#count()*
 doge#helpers#keyseq()	doge.txt	/*doge#helpers#keyseq()*
 doge#helpers#placeholder()	doge.txt	/*doge#helpers#placeholder()*
+doge#helpers#trim()	doge.txt	/*doge#helpers#trim()*
 doge#indent#add()	doge.txt	/*doge#indent#add()*
 doge#token#extract()	doge.txt	/*doge#token#extract()*
 doge#token#replace()	doge.txt	/*doge#token#replace()*
@@ -17,6 +20,7 @@ doge-functions	doge.txt	/*doge-functions*
 doge-intro	doge.txt	/*doge-intro*
 doge-preprocessors	doge.txt	/*doge-preprocessors*
 doge.txt	doge.txt	/*doge.txt*
+g:doge_buffer_mappings	doge.txt	/*g:doge_buffer_mappings*
 g:doge_comment_interactive	doge.txt	/*g:doge_comment_interactive*
 g:doge_enable_mappings	doge.txt	/*g:doge_enable_mappings*
 g:doge_mapping	doge.txt	/*g:doge_mapping*

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -5,7 +5,7 @@ let s:unsupported_msg = '[DoGe] Unsupported version. %s is required.'
 
 if !has('nvim') && (v:version < 700 || !has('patch-7.4.2119'))
   echohl WarningMsg
-  echo printf(s:unsupported_msg, 'Vim v7.4.2219+')
+  echo printf(s:unsupported_msg, 'Vim v7.4.2119+')
   echohl None
   finish
 endif
@@ -103,23 +103,22 @@ if !exists('g:doge_comment_interactive')
   let g:doge_comment_interactive = 1
 endif
 
+" Register all the <Plug> mappings.
 nnoremap <Plug>(doge-generate) :call doge#generate()<CR>
-nnoremap <expr> <Plug>(doge-comment-jump-forward) doge#comment#jump('forward')
-nnoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump('backward')
-inoremap <expr> <Plug>(doge-comment-jump-forward) doge#comment#jump('forward')
-inoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump('backward')
-snoremap <expr> <Plug>(doge-comment-jump-forward) doge#comment#jump('forward')
-snoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump('backward')
+for g:mode in ['n', 'i', 's']
+  execute(printf('%snoremap <expr> <Plug>(doge-comment-jump-forward) doge#comment#jump("forward")', g:mode))
+  execute(printf('%snoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump("backward")', g:mode))
+endfor
+unlet g:mode
 
 if g:doge_enable_mappings == v:true
   execute(printf('nmap <silent> %s <Plug>(doge-generate)', g:doge_mapping))
-  if !g:doge_buffer_mappings
-    execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-    execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
-    execute(printf('imap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-    execute(printf('imap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
-    execute(printf('smap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-    execute(printf('smap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+  if g:doge_buffer_mappings == v:false
+    for g:mode in ['n', 'i', 's']
+      execute(printf('%smap <silent> %s <Plug>(doge-comment-jump-forward)', g:mode, g:doge_mapping_comment_jump_forward))
+      execute(printf('%smap <silent> %s <Plug>(doge-comment-jump-backward)', g:mode, g:doge_mapping_comment_jump_backward))
+    endfor
+    unlet g:mode
   endif
 endif
 

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -70,11 +70,11 @@ endif
 
 if !exists('g:doge_buffer_mappings')
   ""
-  " (Default: 0)
+  " (Default: 1)
   "
   " Mappings to jump forward/backward are applied as buffer mappings when
   " interactive mode starts, and removed when it ends.
-  let g:doge_buffer_mappings = 0
+  let g:doge_buffer_mappings = 1
 endif
 
 if !exists('g:doge_mapping_comment_jump_forward')

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -68,6 +68,15 @@ if !exists('g:doge_mapping')
   let g:doge_mapping = '<Leader>d'
 endif
 
+if !exists('g:doge_buffer_mappings')
+  ""
+  " (Default: 0)
+  "
+  " Mappings to jump forward/backward are applied as buffer mappings when
+  " interactive mode starts, and removed when it ends.
+  let g:doge_buffer_mappings = 0
+endif
+
 if !exists('g:doge_mapping_comment_jump_forward')
   ""
   " (Default: '<Tab>')
@@ -104,12 +113,14 @@ snoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump('backward')
 
 if g:doge_enable_mappings == v:true
   execute(printf('nmap <silent> %s <Plug>(doge-generate)', g:doge_mapping))
-  execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-  execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
-  execute(printf('imap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-  execute(printf('imap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
-  execute(printf('smap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
-  execute(printf('smap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+  if !g:doge_buffer_mappings
+    execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
+    execute(printf('nmap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+    execute(printf('imap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
+    execute(printf('imap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+    execute(printf('smap <silent> %s <Plug>(doge-comment-jump-forward)', g:doge_mapping_comment_jump_forward))
+    execute(printf('smap <silent> %s <Plug>(doge-comment-jump-backward)', g:doge_mapping_comment_jump_backward))
+  endif
 endif
 
 ""

--- a/test/options/doge_buffer_mappings.vader
+++ b/test/options/doge_buffer_mappings.vader
@@ -1,0 +1,33 @@
+# ==============================================================================
+# Tests the functionality for the g:doge_buffer_mappings option.
+# ==============================================================================
+Given php (PHP function without parameters where g:doge_buffer_mappings = 1):
+  function myFunction() {}
+
+Do (trigger doge):
+  :let g:doge_comment_interactive = 1\<CR>
+  \<C-d>
+  Lorem ipsum
+  \<Tab>
+  void
+  \<Tab>
+  Lorem ipsum
+
+# Trigger an additional <Tab> to deactivate DoGe.
+  \<Tab>
+
+Then (all buffer mappings should not exists anymore):
+  AssertEqual 0, hasmapto('<Plug>(doge-comment-jump-forward)', 'nis')
+  AssertEqual 0, hasmapto('<Plug>(doge-comment-jump-backward)', 'nis')
+
+Expect php (generated comment with @param and @return tags):
+  /**
+   * Lorem ipsum
+   *
+   * @return void Lorem ipsum 
+   */
+  function myFunction() {}
+
+Do (let g:doge_comment_interactive = 0):
+# Disable the option again so that upcoming tests will not fail.
+  :let g:doge_comment_interactive = 0\<CR>

--- a/test/options/doge_comment_interactive.vader
+++ b/test/options/doge_comment_interactive.vader
@@ -1,8 +1,5 @@
 # ==============================================================================
 # Tests the functionality for the g:doge_comment_interactive option.
-#
-# We test PHP because we will test the functionality of a commment being
-# inserted above.
 # ==============================================================================
 Given php (PHP function with parameters where g:doge_comment_interactive = 0):
   function myFunction(array &$p1, string $p2, &$p3 = NULL, \Drupal\core\Entity\Node $p4) {}
@@ -183,4 +180,5 @@ Expect python (generated comment with :param tags with brief descriptions):
       pass
 
 Do (let g:doge_comment_interactive = 0):
+# Disable the option again so that upcoming tests will not fail.
   :let g:doge_comment_interactive = 0\<CR>


### PR DESCRIPTION
New option to use buffer mappings instead of normal mappings.
Buffer mappings are enabled when DoGe is successfully started, and
unmapped when finished.

# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [ ] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [ ] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

Same stuff of the PR #43, but cleaned up. The wrap-around feature has been moved to a different PR, since it's a different thing.

Reasons for the PR:

- so that you don't need to reserve a key like `<tab>` for DoGe, that is used sporadically and can use buffer mappings as other snippet plugins do
- fixes #16 and related issues