### PR TITLE
g:doge_wrap_around (default 0)

### DIFF
--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -5,7 +5,8 @@ let s:comment_placeholder = doge#helpers#placeholder()
 
 " vint: next-line -ProhibitUnusedVariable
 function! s:jump_forward() abort
-  let l:next_pos = search(s:comment_placeholder, 'nW')
+  let l:wrap = g:doge_wrap_around ? 'w' : 'W'
+  let l:next_pos = search(s:comment_placeholder, 'n' . l:wrap)
 
   " Check if the next pos we want to jump to is still inside the comment.
   if l:next_pos != 0 && l:next_pos <= b:doge_interactive['lnum_comment_end_pos']
@@ -28,7 +29,8 @@ endfunction
 
 " vint: next-line -ProhibitUnusedVariable
 function! s:jump_backward() abort
-  let l:prev_pos = search(s:comment_placeholder, 'bnW')
+  let l:wrap = g:doge_wrap_around ? 'w' : 'W'
+  let l:prev_pos = search(s:comment_placeholder, 'bn' . l:wrap)
 
   " Check if the prev pos we want to jump to is still inside the comment.
   if l:prev_pos != 0 && l:prev_pos >= b:doge_interactive['lnum_comment_start_pos']

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -51,6 +51,12 @@ The mapping to jump backward to the previous TODO item in a comment. Requires
 
 Jumps interactively through all TODO items in the generated comment.
 
+                                                          *g:doge_wrap_around*
+(Default: 0)
+
+Cycle among placeholders when reaching the last one (or first one if jumping
+backwards).
+
 ==============================================================================
 COMMANDS                                                       *doge-commands*
 

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -68,6 +68,15 @@ if !exists('g:doge_mapping')
   let g:doge_mapping = '<Leader>d'
 endif
 
+if !exists('g:doge_wrap_around')
+  ""
+  " (Default: 0)
+  "
+  " Cycle among placeholders when reaching last one (or first if jumping
+  " backward)
+  let g:doge_wrap_around = 0
+endif
+
 if !exists('g:doge_mapping_comment_jump_forward')
   ""
   " (Default: '<Tab>')


### PR DESCRIPTION
New option to allow placeholder to by cycled, as long as there is more than one left.

# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [ ] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [ ] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

Because I think it's a better behaviour: if there are placeholders left, you can keep cycling them with `<tab>`. Default is 0, because it breaks tests otherwise.