### PR TITLE
Ensure lazyredraw is enabled

### DIFF
--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -25,6 +25,12 @@ endfunction
 " @public
 " Activate doge buffer mappings, if option is set.
 function! doge#activate() abort
+  " Ensure lazyredraw is enabled
+  if &lazyredraw == v:false
+    set lazyredraw
+    let b:doge_lazyredraw = 1
+  endif
+
   if g:doge_comment_interactive == v:false || g:doge_buffer_mappings == v:false
     return
   endif
@@ -44,6 +50,11 @@ endfunction
 " Deactivate doge mappings and unlet buffer variable.
 " Can print a message with the reason of deactivation/termination.
 function! doge#deactivate() abort
+  " Disable lazyredraw if it was previously enabled
+  if exists('b:doge_lazyredraw')
+    set nolazyredraw
+    unlet b:doge_lazyredraw
+  endif
   unlet b:doge_interactive
 
   if g:doge_comment_interactive == v:false || g:doge_buffer_mappings == v:false


### PR DESCRIPTION
Enable lazyredraw in doge#activate(), if disabled.
Reenable in doge#deactivate() if enabled by DoGe.

# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [ ] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [ ] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

[A clear and concise description of why this PR has been made]
