### PR TITLE
g:doge_comment_jump_modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ Default: `1`
 
 Continue to cycle among placeholders when reaching the start or end.
 
+### `g:doge_comment_jump_modes`
+
+Default: `['n', 'i', 's']`
+
+Defines the modes in which doge will jump forward and backward when interactive
+mode is active. For example: removing 'i' would allow you to use <Tab> for
+autocompletion in insert mode.
+
 # Commands
 
 ### `:DogeGenerate`

--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -43,7 +43,7 @@ function! doge#activate() abort
         \ g:doge_mapping_comment_jump_forward,
         \ g:doge_mapping_comment_jump_backward,
         \ ]
-  for l:mode in ['n', 'i', 's']
+  for l:mode in g:doge_comment_jump_modes
     execute(printf('%smap <nowait> <silent> <buffer> %s <Plug>(doge-comment-jump-forward)', l:mode, l:f))
     execute(printf('%smap <nowait> <silent> <buffer> %s <Plug>(doge-comment-jump-backward)', l:mode, l:b))
   endfor
@@ -72,7 +72,7 @@ function! doge#deactivate() abort
         \ g:doge_mapping_comment_jump_forward,
         \ g:doge_mapping_comment_jump_backward,
         \ ]
-  for l:mode in ['n', 'i', 's']
+  for l:mode in g:doge_comment_jump_modes
     execute(printf('%sunmap <buffer> %s', l:mode, l:f))
     execute(printf('%sunmap <buffer> %s', l:mode, l:b))
   endfor

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -65,8 +65,9 @@ Continue to cycle among placeholders when reaching the start or end.
                                                    *g:doge_comment_jump_modes*
 (Default: ['n', 'i', 's'])
 
-Defines the modes in which doge jump mapping should work. For example,
-removing 'i' would allow you to use <Tab> for autocompletion in insert mode.
+Defines the modes in which doge will jump forward and backward when
+interactive mode is active. For example: removing 'i' would allow you to use
+<Tab> for autocompletion in insert mode.
 
 ==============================================================================
 COMMANDS                                                       *doge-commands*

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -62,6 +62,12 @@ Jumps interactively through all TODO items in the generated comment.
 
 Continue to cycle among placeholders when reaching the start or end.
 
+                                                   *g:doge_comment_jump_modes*
+(Default: ['n', 'i', 's'])
+
+Defines the modes in which doge jump mapping should work. For example,
+removing 'i' would allow you to use <Tab> for autocompletion in insert mode.
+
 ==============================================================================
 COMMANDS                                                       *doge-commands*
 

--- a/doc/tags
+++ b/doc/tags
@@ -22,6 +22,7 @@ doge-preprocessors	doge.txt	/*doge-preprocessors*
 doge.txt	doge.txt	/*doge.txt*
 g:doge_buffer_mappings	doge.txt	/*g:doge_buffer_mappings*
 g:doge_comment_interactive	doge.txt	/*g:doge_comment_interactive*
+g:doge_comment_jump_modes	doge.txt	/*g:doge_comment_jump_modes*
 g:doge_comment_jump_wrap	doge.txt	/*g:doge_comment_jump_wrap*
 g:doge_enable_mappings	doge.txt	/*g:doge_enable_mappings*
 g:doge_mapping	doge.txt	/*g:doge_mapping*

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -115,7 +115,9 @@ if !exists('g:doge_comment_jump_modes')
   ""
   " (Default: ['n', 'i', 's'])
   "
-  " Define the modes in which doge jump mapping should work.
+  " Defines the modes in which doge will jump forward and backward when
+  " interactive mode is active. For example: removing 'i' would allow you to use
+  " <Tab> for autocompletion in insert mode.
   let g:doge_comment_jump_modes = ['n', 'i', 's']
 endif
 

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -111,24 +111,31 @@ if !exists('g:doge_comment_jump_wrap')
   let g:doge_comment_jump_wrap = 1
 endif
 
+if !exists('g:doge_comment_jump_modes')
+  ""
+  " (Default: ['n', 'i', 's'])
+  "
+  " Define the modes in which doge jump mapping should work.
+  let g:doge_comment_jump_modes = ['n', 'i', 's']
+endif
+
 " Register all the <Plug> mappings.
 nnoremap <Plug>(doge-generate) :call doge#generate()<CR>
-for g:mode in ['n', 'i', 's']
-  execute(printf('%snoremap <expr> <Plug>(doge-comment-jump-forward) doge#comment#jump("forward")', g:mode))
-  execute(printf('%snoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump("backward")', g:mode))
+for s:mode in g:doge_comment_jump_modes
+  execute(printf('%snoremap <expr> <Plug>(doge-comment-jump-forward) doge#comment#jump("forward")', s:mode))
+  execute(printf('%snoremap <expr> <Plug>(doge-comment-jump-backward) doge#comment#jump("backward")', s:mode))
 endfor
-unlet g:mode
 
 if g:doge_enable_mappings == v:true
   execute(printf('nmap <silent> %s <Plug>(doge-generate)', g:doge_mapping))
   if g:doge_buffer_mappings == v:false
-    for g:mode in ['n', 'i', 's']
-      execute(printf('%smap <silent> %s <Plug>(doge-comment-jump-forward)', g:mode, g:doge_mapping_comment_jump_forward))
-      execute(printf('%smap <silent> %s <Plug>(doge-comment-jump-backward)', g:mode, g:doge_mapping_comment_jump_backward))
+    for s:mode in g:doge_comment_jump_modes
+      execute(printf('%smap <silent> %s <Plug>(doge-comment-jump-forward)', s:mode, g:doge_mapping_comment_jump_forward))
+      execute(printf('%smap <silent> %s <Plug>(doge-comment-jump-backward)', s:mode, g:doge_mapping_comment_jump_backward))
     endfor
-    unlet g:mode
   endif
 endif
+unlet s:mode
 
 ""
 " Command to generate documentation.


### PR DESCRIPTION
Defines the modes in which doge jump mapping should work.
Default: ['n', 'i', 's']

# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [ ] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [ ] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

For those that use Tab for autocompletion/snippet expansion, so that it's still possible to use it that way in a doge block. For me normal mode and select mode are enough.
