### PR TITLE
Deactivate doge if no placeholders left

### DIFF
--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -151,7 +151,6 @@ function! doge#comment#update_interactive_comment_info() abort
       let b:doge_interactive['lnum_comment_end_pos'] = l:lnum_comment_end_pos - 1
     endif
 
-
     " Update the amount of TODO items left.
     let b:doge_interactive['todo_count'] = doge#helpers#count(
           \ s:comment_placeholder,

--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -150,13 +150,6 @@ function! doge#comment#update_interactive_comment_info() abort
 
       let b:doge_interactive['lnum_comment_end_pos'] = l:lnum_comment_end_pos - 1
     endif
-
-    " Update the amount of TODO items left.
-    let b:doge_interactive['todo_count'] = doge#helpers#count(
-          \ s:comment_placeholder,
-          \ b:doge_interactive['lnum_comment_start_pos'],
-          \ b:doge_interactive['lnum_comment_end_pos']
-          \ )
   endif
 endfunction
 
@@ -167,7 +160,12 @@ endfunction
 " @setting(g:doge_comment_interactive) to be enabled.
 function! doge#comment#deactivate_when_done(...) abort
   if exists('b:doge_interactive')
-    if b:doge_interactive['todo_count'] == 0
+    let l:todo_count = doge#helpers#count(
+          \ s:comment_placeholder,
+          \ b:doge_interactive['lnum_comment_start_pos'],
+          \ b:doge_interactive['lnum_comment_end_pos']
+          \ )
+    if l:todo_count == 0
       call doge#deactivate()
     endif
   endif

--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -150,20 +150,27 @@ function! doge#comment#update_interactive_comment_info() abort
 
       let b:doge_interactive['lnum_comment_end_pos'] = l:lnum_comment_end_pos - 1
     endif
+
+
+    " Update the amount of TODO items left.
+    let b:doge_interactive['todo_count'] = doge#helpers#count(
+          \ s:comment_placeholder,
+          \ b:doge_interactive['lnum_comment_start_pos'],
+          \ b:doge_interactive['lnum_comment_end_pos']
+          \ )
   endif
 endfunction
 
-function! doge#comment#check_if_placeholders_left() abort
-  " Called on InsertLeave.
-  " If there are no placeholders left at this point, it's safe to assume that
-  " we're finished and interactive mode should be terminated.
+""
+" @public
+" This function is trigged by the auto-commands InsertLeave and TextChanged and
+" will deactivate doge when there are no more TODO items left. Requires
+" @setting(g:doge_comment_interactive) to be enabled.
+function! doge#comment#deactivate_when_done(...) abort
   if exists('b:doge_interactive')
-    let l:pos = getcurpos()[1:2]
-    call cursor(b:doge_interactive['lnum_comment_start_pos'], 1)
-    if search(s:comment_placeholder, 'W', b:doge_interactive['lnum_comment_end_pos']) == v:false
+    if b:doge_interactive['todo_count'] == 0
       call doge#deactivate()
     endif
-    call cursor(l:pos)
   endif
 endfunction
 

--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -153,5 +153,19 @@ function! doge#comment#update_interactive_comment_info() abort
   endif
 endfunction
 
+function! doge#comment#check_if_placeholders_left() abort
+  " Called on InsertLeave.
+  " If there are no placeholders left at this point, it's safe to assume that
+  " we're finished and interactive mode should be terminated.
+  if exists('b:doge_interactive')
+    let l:pos = getcurpos()[1:2]
+    call cursor(b:doge_interactive['lnum_comment_start_pos'], 1)
+    if search(s:comment_placeholder, 'W', b:doge_interactive['lnum_comment_end_pos']) == v:false
+      call doge#deactivate()
+    endif
+    call cursor(l:pos)
+  endif
+endfunction
+
 let &cpoptions = s:save_cpo
 unlet s:save_cpo

--- a/autoload/doge/comment.vim
+++ b/autoload/doge/comment.vim
@@ -160,14 +160,12 @@ endfunction
 " @setting(g:doge_comment_interactive) to be enabled.
 function! doge#comment#deactivate_when_done(...) abort
   if exists('b:doge_interactive')
-    let l:todo_count = doge#helpers#count(
-          \ s:comment_placeholder,
-          \ b:doge_interactive['lnum_comment_start_pos'],
-          \ b:doge_interactive['lnum_comment_end_pos']
-          \ )
-    if l:todo_count == 0
+    let l:pos = getcurpos()[1:2]
+    call cursor(b:doge_interactive['lnum_comment_start_pos'], 1)
+    if search(s:comment_placeholder, 'W', b:doge_interactive['lnum_comment_end_pos']) == v:false
       call doge#deactivate()
     endif
+    call cursor(l:pos)
   endif
 endfunction
 

--- a/autoload/doge/generate.vim
+++ b/autoload/doge/generate.vim
@@ -145,7 +145,6 @@ function! doge#generate#pattern(pattern) abort
       if l:todo_count > 0
         let b:doge_interactive = {
               \ 'comment': l:comment,
-              \ 'todo_count': l:todo_count,
               \ 'lnum_comment_start_pos': (l:comment_lnum_insert_position + 1),
               \ 'lnum_comment_end_pos': (l:comment_lnum_insert_position + len(l:comment)),
               \ }

--- a/autoload/doge/generate.vim
+++ b/autoload/doge/generate.vim
@@ -145,6 +145,7 @@ function! doge#generate#pattern(pattern) abort
       if l:todo_count > 0
         let b:doge_interactive = {
               \ 'comment': l:comment,
+              \ 'todo_count': l:todo_count,
               \ 'lnum_comment_start_pos': (l:comment_lnum_insert_position + 1),
               \ 'lnum_comment_end_pos': (l:comment_lnum_insert_position + len(l:comment)),
               \ }

--- a/doc/doge.txt
+++ b/doc/doge.txt
@@ -100,6 +100,11 @@ doge#comment#update_interactive_comment_info()
   the b:doge_interactive variable where needed. Requires
   |g:doge_comment_interactive| to be enabled.
 
+doge#comment#deactivate_when_done()      *doge#comment#deactivate_when_done()*
+  This function is trigged by the auto-commands InsertLeave and TextChanged
+  and will deactivate doge when there are no more TODO items left. Requires
+  |g:doge_comment_interactive| to be enabled.
+
 doge#generate#pattern({pattern})                     *doge#generate#pattern()*
   Generates a comment based on a given pattern.
 

--- a/doc/tags
+++ b/doc/tags
@@ -1,6 +1,7 @@
 :DogeGenerate	doge.txt	/*:DogeGenerate*
 doge	doge.txt	/*doge*
 doge#activate()	doge.txt	/*doge#activate()*
+doge#comment#deactivate_when_done()	doge.txt	/*doge#comment#deactivate_when_done()*
 doge#comment#jump()	doge.txt	/*doge#comment#jump()*
 doge#comment#update_interactive_comment_info()	doge.txt	/*doge#comment#update_interactive_comment_info()*
 doge#deactivate()	doge.txt	/*doge#deactivate()*

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -137,6 +137,7 @@ command! -nargs=0 DogeGenerate call doge#generate()
 augroup doge
   autocmd!
   autocmd TextChangedI * call doge#comment#update_interactive_comment_info()
+  autocmd InsertLeave  * call doge#comment#check_if_placeholders_left()
 augroup END
 
 let &cpoptions = s:save_cpo

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -138,6 +138,7 @@ augroup doge
   autocmd!
   autocmd TextChangedI * call doge#comment#update_interactive_comment_info()
   autocmd InsertLeave  * call doge#comment#check_if_placeholders_left()
+  autocmd TextChanged  * call doge#comment#check_if_placeholders_left()
 augroup END
 
 let &cpoptions = s:save_cpo

--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -146,8 +146,8 @@ command! -nargs=0 DogeGenerate call doge#generate()
 augroup doge
   autocmd!
   autocmd TextChangedI * call doge#comment#update_interactive_comment_info()
-  autocmd InsertLeave  * call doge#comment#check_if_placeholders_left()
-  autocmd TextChanged  * call doge#comment#check_if_placeholders_left()
+  autocmd InsertLeave  * call doge#comment#deactivate_when_done()
+  autocmd TextChanged  * call doge#comment#deactivate_when_done()
 augroup END
 
 let &cpoptions = s:save_cpo


### PR DESCRIPTION
Check on InsertLeave if there are placeholders left, if not, deactivate
doge.

# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [ ] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [ ] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

Before this PR, after the last placeholder was consumed, the first Tab keypress would still use doge mapping, which is undesiderable. It checks on InsertLeave, so that if the placeholder is reached, but not consumed, doge remains active.