### PR TITLE
Add required prereq for c/c++

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,13 +236,12 @@ $ python3
 #### Manual compiling
 
 If you compiled libclang manually, then make sure that your `$PATH` and
-`$LD_LIBRARY_PATH` are set correctly. The libclang binary its location should
-be defined in the `$LD_LIBRARY_PATH`.
+`$LD_LIBRARY_PATH` are set correctly. 
 
-E.g.
+The libclang binary its location should be defined in the `$LD_LIBRARY_PATH`:
 
 ```sh
-# for macOS
+# MacOS
 export LD_LIBRARY_PATH="/Library/Developer/CommandLineTools/usr/lib/"
 ```
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ This is the parser that is being used for generating proper documentation.
 #### Prerequisites
 - Vim requires to be compiled with python 3.
 - Python 3.5+
+- `pip3 install clang`
 
 #### Package manager
 
@@ -237,6 +238,13 @@ $ python3
 If you compiled libclang manually, then make sure that your `$PATH` and
 `$LD_LIBRARY_PATH` are set correctly. The libclang binary its location should
 be defined in the `$LD_LIBRARY_PATH`.
+
+E.g.
+
+```sh
+# for macOS
+export LD_LIBRARY_PATH="/Library/Developer/CommandLineTools/usr/lib/"
+```
 
 # Help
 


### PR DESCRIPTION
# Prelude

- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

This is a small update to the readme to include a required python package which is needed for c/c++. It also adds an example of how to set the `LD_LIBRARY_PATH` variable.