### PR TITLE
c/cpp: Use compile_commands if present to determine compiler args

### DIFF
--- a/generators/libclang.py
+++ b/generators/libclang.py
@@ -31,8 +31,14 @@ If you compiled manually:
 Make sure that your $PATH and $LD_LIBRARY_PATH are set correctly.
 The libclang binary its location should be defined in the $LD_LIBRARY_PATH.
 """
-
-from clang.cindex import Index, CursorKind, Cursor
+from clang.cindex import (
+    Index,
+    CursorKind,
+    Cursor,
+    SourceLocation,
+    CompilationDatabase,
+    CompilationDatabaseError,
+)
 import sys
 import json
 import vim
@@ -113,19 +119,79 @@ def print_func_decl(node: Cursor):
     :param node Cursor: The node to parse.
     """
     output = {}
-    output['name'] = node.spelling
-    output['returnType'] = node.result_type.spelling
-    output['parameters'] = []
+    output["name"] = node.spelling
+    output["returnType"] = node.result_type.spelling
+    output["parameters"] = []
     for child in node.get_children():
         if child.kind in [CursorKind.PARM_DECL, CursorKind.TEMPLATE_TYPE_PARAMETER]:
-            param_type = 'param'
+            param_type = "param"
             if child.kind == CursorKind.TEMPLATE_TYPE_PARAMETER:
-                param_type = 'tparam'
-            output['parameters'].append({
-                'param-type': param_type,
-                'name': child.spelling,
-            })
+                param_type = "tparam"
+            output["parameters"].append(
+                {"param-type": param_type, "name": child.spelling}
+            )
     print(json.dumps(output))
+
+
+def check_file_with_compile_flags(filename, args, filters, line, column):
+    """
+    Check the actual cpp file with the compile arguments retrieved from compile_commands.json.
+
+    :param filename: file to check
+    :param args: arguments to pass to libclang
+    :param filters: the filters to check results for
+    :param line: the single line where the token is located
+    :param column: the column where the token is located
+    """
+    index = Index.create()
+    tu = index.parse(filename, args=args)
+    if tu:
+        sourceLocation = SourceLocation.from_position(
+            tu, tu.get_file(filename), line, column
+        )
+        node = Cursor.from_location(tu, sourceLocation)
+        if node and node.kind in filters:
+            if node.kind == CursorKind.FIELD_DECL:
+                print_field_decl(node)
+            elif node.kind == CursorKind.STRUCT_DECL:
+                print_struct_decl(node)
+            elif node.kind in [
+                CursorKind.CONSTRUCTOR,
+                CursorKind.CXX_METHOD,
+                CursorKind.FUNCTION_DECL,
+                CursorKind.FUNCTION_TEMPLATE,
+                CursorKind.CLASS_TEMPLATE,
+            ]:
+                print_func_decl(node)
+
+
+def check_file_with_transformation(filename, args, filters, line):
+    """
+    Check a file with the old mechanism of normalizing the signature to a signle line.
+
+    :param filename: file to check
+    :param args: arguments to pass to libclang
+    :param filters: the filters to check results for
+    :param line: the single line where the token is located
+    """
+    index = Index.create()
+    tu = index.parse(filename, args=args)
+    if tu:
+        node = find_node(tu.cursor, line)
+        if node and node.kind in filters:
+            if node.kind == CursorKind.FIELD_DECL:
+                print_field_decl(node)
+            elif node.kind == CursorKind.STRUCT_DECL:
+                print_struct_decl(node)
+            elif node.kind in [
+                CursorKind.CONSTRUCTOR,
+                CursorKind.CXX_METHOD,
+                CursorKind.FUNCTION_DECL,
+                CursorKind.FUNCTION_TEMPLATE,
+                CursorKind.CLASS_TEMPLATE,
+            ]:
+                print_func_decl(node)
+
 
 def main():
     # This script should be run using filters and only those nodes who match the
@@ -136,48 +202,55 @@ def main():
     filters = [getattr(CursorKind, arg) for arg in sys.argv]
 
     file_ext = vim.eval("expand('%:p:e')")
-    ext = file_ext if file_ext else vim.eval('&filetype')
-    workdir = vim.eval("expand('%:p:h')")
-
-    try:
-        args = vim.eval('g:doge_clang_args')
-    except vim.error:
-        args = []
-
-    lines = vim.eval("getline(line(1), line('$'))")
+    ext = file_ext if file_ext else vim.eval("&filetype")
+    workdir = os.getcwd()
+    possible_compilation_db = os.path.join(workdir, "compile_commands.json")
+    filename_rel = vim.eval("expand('%')")
+    filename = os.path.join(workdir, filename_rel)
     current_line = int(vim.eval("line('.')"))
+    current_column = int(vim.eval("col('.')"))
 
-    # Normalize the expression by transforming everything into 1 line.
-    opener_pos = int(vim.eval("search('\m[{;]', 'n')"))
-    normalized_expr = vim.eval("join(map(getline(line('.'), {}), 'doge#helpers#trim(v:val)'), ' ')".format(opener_pos))
-    del lines[current_line-1:opener_pos]
-    lines.insert(current_line-1, normalized_expr)
+    if os.path.exists(possible_compilation_db):
+        try:
+            compdb = CompilationDatabase.fromDirectory(workdir)
+            ccs = compdb.getCompileCommands(filename_rel)
+            if ccs is not None:
+                ccargs = list(ccs[0].arguments)[1:-1]
+            else:
+                ccargs = []
+        except CompilationDatabaseError:
+            ccargs = []
 
-    # Save the lines to a temp file and parse that file.
-    fd, filename = tempfile.mkstemp(dir=workdir, prefix='vim-doge-', suffix='.{}'.format(ext))
-    try:
-        with os.fdopen(fd, 'w') as tmp:
-            tmp.write('\n'.join(lines))
+        try:
+            check_file_with_compile_flags(filename, ccargs, filters, current_line, current_column)
+        except Exception as e:
+            print(e)
 
-        index = Index.create()
-        tu = index.parse(filename, args=args)
-        if tu:
-            node = find_node(tu.cursor, current_line)
-            if node and node.kind in filters:
-                if node.kind == CursorKind.FIELD_DECL:
-                    print_field_decl(node)
-                elif node.kind == CursorKind.STRUCT_DECL:
-                    print_struct_decl(node)
-                elif node.kind in [CursorKind.CONSTRUCTOR,
-                                   CursorKind.CXX_METHOD,
-                                   CursorKind.FUNCTION_DECL,
-                                   CursorKind.FUNCTION_TEMPLATE,
-                                   CursorKind.CLASS_TEMPLATE]:
-                    print_func_decl(node)
-    except Exception as e:
-        print(e)
-    finally:
-        os.remove(filename)
+    else:
+        # Normalize the expression by transforming everything into 1 line.
+        opener_pos = int(vim.eval("search('\m[{;]', 'n')"))
+        normalized_expr = vim.eval("join(map(getline(line('.'), {}), 'doge#helpers#trim(v:val)'), ' ')".format(opener_pos))
+        workdir = vim.eval("expand('%:p:h')")
+        lines = vim.eval("getline(line(1), line('$'))")
+        del lines[current_line-1:opener_pos]
+        lines.insert(current_line-1, normalized_expr)
 
-if __name__ == '__main__':
+        try:
+            args = vim.eval('g:doge_clang_args')
+        except vim.error:
+            args = []
+
+        # Save the lines to a temp file and parse that file.
+        fd, filename = tempfile.mkstemp(dir=workdir, prefix='vim-doge-', suffix='.{}'.format(ext))
+        try:
+            with os.fdopen(fd, 'w') as tmp:
+                tmp.write('\n'.join(lines))
+            check_file_with_transformation(filename, args, filters, current_line)
+        except Exception as e:
+            print(e)
+        finally:
+            os.remove(filename)
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
The old behavior without a compile_commands.json present in the working
dir was kept available. If this file is present, the new mechanism
will use the actual compiler flags as specified by the build system to
parse the actual file the user is working in and retrieve info about the
token under the user's cursor.

# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [x ] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x ] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

In environments where the compiler generates a compile commands database (compile_commands.json). The clang toolchain can use this database to parse files in the exact way the compiler would. This enables reliable identification of the token type for which the user has requested documentation to be generated and associated tokens, such as parameters.
This PR is probably par from perfect, but it improves upon the existing mechanism if a compile commands database is present. The old mechanism for parsing has been preserved.

It should be noted that:
* It is assumed the compile_commands.json file is in the current working dir, as that should commonly be the project root and I didn't feel like searching for it, as that requires quite a bit of heuristics.
* The available token types are limited from DoGe's side.
* The current way of triggering the generator is suboptimal, since it is triggered 3 times, when one pass would be sufficient for the clang-based indexer. This makes documentation generation far slower than it would need to be, resulting in a noticable delay.
* Since header files have no entry inside the compile commands db, clang uses an internal heuristic to guess the correct flags for these files. This can very seldomly lead to incorrect results.