### PR TITLE
fix(ruby): Fix ruby keyword arguments and without parentheses

### DIFF
--- a/autoload/doge/pattern.vim
+++ b/autoload/doge/pattern.vim
@@ -26,21 +26,8 @@ function! doge#pattern#generate(pattern) abort
     endif
   else
     " Skip if the current line does not match the main pattern.
-    let l:curr_line_raw = escape(doge#helpers#trim(join(l:lines, "\n")), '\')
-    let l:match = v:null
-    if type(a:pattern['match']) == type('')
-      if l:curr_line_raw =~# a:pattern['match']
-        let l:match = a:pattern['match']
-      endif
-    elseif type(a:pattern['match']) == type([])
-      for l:m in a:pattern['match']
-        if l:curr_line_raw =~# l:m
-          let l:match = l:m
-          break
-        endif
-      endfor
-    endif
-    if l:match is v:null
+    let l:curr_line_raw = escape(doge#helpers#trim(join(l:lines, ' ')), '\')
+    if l:curr_line_raw !~# a:pattern['match']
       return 0
     endif
 
@@ -56,7 +43,7 @@ function! doge#pattern#generate(pattern) abort
     " Extract the primary tokens.
     let l:tokens = get(doge#token#extract(
           \ l:curr_line,
-          \ l:match,
+          \ a:pattern['match'],
           \ a:pattern['tokens']
           \ ), 0, {})
   endif

--- a/autoload/doge/pattern.vim
+++ b/autoload/doge/pattern.vim
@@ -26,7 +26,9 @@ function! doge#pattern#generate(pattern) abort
     endif
   else
     " Skip if the current line does not match the main pattern.
-    let l:curr_line_raw = escape(doge#helpers#trim(join(l:lines, ' ')), '\')
+    let l:glue = has_key(a:pattern, 'normalize')
+          \ && a:pattern['normalize'] == v:false ? "\n" : ' '
+    let l:curr_line_raw = escape(doge#helpers#trim(join(l:lines, l:glue)), '\')
     if l:curr_line_raw !~# a:pattern['match']
       return 0
     endif

--- a/autoload/doge/pattern.vim
+++ b/autoload/doge/pattern.vim
@@ -26,8 +26,21 @@ function! doge#pattern#generate(pattern) abort
     endif
   else
     " Skip if the current line does not match the main pattern.
-    let l:curr_line_raw = escape(doge#helpers#trim(join(l:lines, ' ')), '\')
-    if l:curr_line_raw !~# a:pattern['match']
+    let l:curr_line_raw = escape(doge#helpers#trim(join(l:lines, "\n")), '\')
+    let l:match = v:null
+    if type(a:pattern['match']) == type('')
+      if l:curr_line_raw =~# a:pattern['match']
+        let l:match = a:pattern['match']
+      endif
+    elseif type(a:pattern['match']) == type([])
+      for l:m in a:pattern['match']
+        if l:curr_line_raw =~# l:m
+          let l:match = l:m
+          break
+        endif
+      endfor
+    endif
+    if l:match is v:null
       return 0
     endif
 
@@ -43,7 +56,7 @@ function! doge#pattern#generate(pattern) abort
     " Extract the primary tokens.
     let l:tokens = get(doge#token#extract(
           \ l:curr_line,
-          \ a:pattern['match'],
+          \ l:match,
           \ a:pattern['tokens']
           \ ), 0, {})
   endif

--- a/autoload/doge/token.vim
+++ b/autoload/doge/token.vim
@@ -125,10 +125,9 @@ endfunction
 " value of that group. The regex groups in the 'regex' parameter should be
 " symmetrical in length to the 'regex_group_names' parameter.
 function! doge#token#extract(text, regex, regex_group_names) abort
-  let l:submatches = []
-  call substitute(a:text, a:regex, '\=add(l:submatches, submatch(0))', 'g')
+  let l:matches = []
+  call substitute(a:text, a:regex, '\=add(l:matches, submatch(0))', 'g')
 
-  let l:matches = map(l:submatches, { k, v -> doge#helpers#trim(v) })
   let l:tokens = []
 
   " We can expect a list of matches like:

--- a/autoload/doge/token.vim
+++ b/autoload/doge/token.vim
@@ -125,8 +125,10 @@ endfunction
 " value of that group. The regex groups in the 'regex' parameter should be
 " symmetrical in length to the 'regex_group_names' parameter.
 function! doge#token#extract(text, regex, regex_group_names) abort
-  let l:matches = []
-  call substitute(a:text, a:regex, '\=add(l:matches, submatch(0))', 'g')
+  let l:submatches = []
+  call substitute(a:text, a:regex, '\=add(l:submatches, submatch(0))', 'g')
+
+  let l:matches = map(l:submatches, { k, v -> doge#helpers#trim(v) })
 
   let l:tokens = []
 

--- a/autoload/doge/token.vim
+++ b/autoload/doge/token.vim
@@ -129,7 +129,6 @@ function! doge#token#extract(text, regex, regex_group_names) abort
   call substitute(a:text, a:regex, '\=add(l:submatches, submatch(0))', 'g')
 
   let l:matches = map(l:submatches, { k, v -> doge#helpers#trim(v) })
-
   let l:tokens = []
 
   " We can expect a list of matches like:

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -45,7 +45,8 @@ let s:pattern_base = {
 " def self.class_parameters p1,p2=4, *p3
 " ------------------------------------------------------------------------------
 let s:function_and_class_method_pattern = doge#helpers#deepextend(s:pattern_base, {
-\  'match': '\m^def\s\+\%([^=(! ]\+\)[=!]\?\s*(\?\s*\(\(\%(\*\{0,2}&\?[[:alnum:]_]\+\%(\s*=\s*[^, ]\+\)\?\)\%(\s*,\s*\)\?\)*\)\s*)\?.\{-}',
+\  'normalize': 0,
+\  'match': '\m^def\s\+\%([^=(!\n ]\+\)[=!]\?\s*\((\_.\{-})\|[^\n]\+\)\?',
 \  'tokens': ['parameters'],
 \})
 

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -20,7 +20,7 @@ let b:doge_patterns = doge#buffer#get_patterns()
 " ==============================================================================
 let s:pattern_base = {
 \  'parameters': {
-\    'match': '\m\([[:alnum:]_]\+\)\%(\s*=\s*[^,]\+\)\?',
+\    'match': '\m\([[:alnum:]_]\+\)\%(\s*[=:]\s*[^,]\+\)\?',
 \    'tokens': ['name'],
 \    'format': '@param {name} [!type] !description',
 \  },
@@ -37,12 +37,20 @@ let s:pattern_base = {
 " Matches regular function expressions and class methods.
 " ------------------------------------------------------------------------------
 " def myFunc(p1, p_2 = some_default_value)
-" def def parameters (p1,p2=4, p3*)
+" def parameters (p1,p2=4, *p3)
+" def parameters p1, p2 = 4, *p3
 " def where(attribute, type = nil, **options)
 " def each(&block)
+" def self.class_method(attribute)
+" def self.class_parameters p1,p2=4, *p3
 " ------------------------------------------------------------------------------
+let s:parameters_matches = [
+\   '(\(.\{-}\))',
+\   '\s\+\([^\n]*\)',
+\   '\n',
+\ ]
 let s:function_and_class_method_pattern = doge#helpers#deepextend(s:pattern_base, {
-\  'match': '\m^def\s\+\%([^=(!]\+\)[=!]\?\s*(\(.\{-}\))',
+\  'match': map(s:parameters_matches, { i, m -> '\m^def\s\+\%([^=(!\n ]\+\)[=!]\?\s*' . m}),
 \  'tokens': ['parameters'],
 \})
 

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -44,13 +44,8 @@ let s:pattern_base = {
 " def self.class_method(attribute)
 " def self.class_parameters p1,p2=4, *p3
 " ------------------------------------------------------------------------------
-let s:parameters_matches = [
-\   '(\(.\{-}\))',
-\   '\s\+\([^\n]*\)',
-\   '\n',
-\ ]
 let s:function_and_class_method_pattern = doge#helpers#deepextend(s:pattern_base, {
-\  'match': map(s:parameters_matches, { i, m -> '\m^def\s\+\%([^=(!\n ]\+\)[=!]\?\s*' . m}),
+\  'match': '\m^def\s\+\%([^=(! ]\+\)[=!]\?\s*(\?\s*\(\(\%(\*\{0,2}&\?[[:alnum:]_]\+\%(\s*=\s*[^, ]\+\)\?\)\%(\s*,\s*\)\?\)*\)\s*)\?.\{-}',
 \  'tokens': ['parameters'],
 \})
 

--- a/playground/test.rb
+++ b/playground/test.rb
@@ -12,10 +12,31 @@ def myFunc (format = :html)
 end
 
 # [TODO:description]
+def myFunc
+end
+
+# [TODO:description]
+# @param format [[TODO:type]] [TODO:description]
+def myFunc format = :html
+end
+
+# [TODO:description]
+# @param format [[TODO:type]] [TODO:description]
+def myFunc(format: :html)
+end
+
+# [TODO:description]
 # @param p1 [[TODO:type]] [TODO:description]
 # @param p2 [[TODO:type]] [TODO:description]
 # @param p3 [[TODO:type]] [TODO:description]
-def parameters (p1,p2=4, p3*)
+def parameters (p1,p2=4, *p3)
+end
+
+# [TODO:description]
+# @param p1 [[TODO:type]] [TODO:description]
+# @param p2 [[TODO:type]] [TODO:description]
+# @param p3 [[TODO:type]] [TODO:description]
+def parameters p1,p2=4, *p3
 end
 
 # [TODO:description]
@@ -55,3 +76,4 @@ module ClassMethods
     # @param block [[TODO:type]] [TODO:description]
     def each(&block)
     end
+end

--- a/playground/test.rb
+++ b/playground/test.rb
@@ -29,14 +29,15 @@ end
 # @param p1 [[TODO:type]] [TODO:description]
 # @param p2 [[TODO:type]] [TODO:description]
 # @param p3 [[TODO:type]] [TODO:description]
-def parameters (p1,p2=4, *p3)
+# @param p4 [[TODO:type]] [TODO:description]
+def parameters (p1,p2=4, *p3,**p4)
 end
 
 # [TODO:description]
 # @param p1 [[TODO:type]] [TODO:description]
 # @param p2 [[TODO:type]] [TODO:description]
 # @param p3 [[TODO:type]] [TODO:description]
-def parameters p1,p2=4, *p3
+def parameters p1,p2=4, *p3,**p4
 end
 
 # [TODO:description]

--- a/playground/test.rb
+++ b/playground/test.rb
@@ -37,6 +37,7 @@ end
 # @param p1 [[TODO:type]] [TODO:description]
 # @param p2 [[TODO:type]] [TODO:description]
 # @param p3 [[TODO:type]] [TODO:description]
+# @param p4 [[TODO:type]] [TODO:description]
 def parameters p1,p2=4, *p3,**p4
 end
 

--- a/test/filetypes/ruby/functions.vader
+++ b/test/filetypes/ruby/functions.vader
@@ -110,7 +110,7 @@ Expect ruby (generated comment with @param tags):
 # ------------------------------------------------------------------------------
 
 Given ruby (function with paramters containing '*' in its name):
-  def parameters (p1,p2=4, p3*)
+  def parameters (p1,p2=4, *p3, **p4)
   end
 
 Do (trigger doge):
@@ -121,7 +121,26 @@ Expect ruby (generated comment with @param tags):
   # @param p1 [[TODO:type]] [TODO:description]
   # @param p2 [[TODO:type]] [TODO:description]
   # @param p3 [[TODO:type]] [TODO:description]
-  def parameters (p1,p2=4, p3*)
+  # @param p4 [[TODO:type]] [TODO:description]
+  def parameters (p1,p2=4, *p3, **p4)
+  end
+
+# ------------------------------------------------------------------------------
+
+Given ruby (function with paramters containing '*' in its name and without parentheses):
+  def parameters p1,p2=4, *p3, **p4
+  end
+
+Do (trigger doge):
+  \<C-d>
+
+Expect ruby (generated comment with @param tags):
+  # [TODO:description]
+  # @param p1 [[TODO:type]] [TODO:description]
+  # @param p2 [[TODO:type]] [TODO:description]
+  # @param p3 [[TODO:type]] [TODO:description]
+  # @param p4 [[TODO:type]] [TODO:description]
+  def parameters p1,p2=4, *p3, **p4
   end
 
 # ------------------------------------------------------------------------------

--- a/test/filetypes/ruby/functions.vader
+++ b/test/filetypes/ruby/functions.vader
@@ -1,7 +1,7 @@
 # ==============================================================================
 # Functions without parameters.
 # ==============================================================================
-Given ruby (function without parameters):
+Given ruby (function without parameters and with parentheses):
   def myFunc() # inline comment
     val = 1
   end
@@ -52,7 +52,7 @@ Expect ruby (generated comment with @param tags):
 
 # ------------------------------------------------------------------------------
 
-Given ruby (function with parameters but without parentheses):
+Given ruby (function with parameters without parentheses):
   def myFunc p1, p_2 = some_default_value # inline comment
     val = 1
   end
@@ -143,7 +143,7 @@ Expect ruby (generated comment with @param tags):
 
 # ------------------------------------------------------------------------------
 
-Given ruby (function with multiline paramters):
+Given ruby (function with multiline parameters):
   def parameters ( #inline comment
     p1,
     p2=4,

--- a/test/filetypes/ruby/functions.vader
+++ b/test/filetypes/ruby/functions.vader
@@ -13,10 +13,24 @@ Expect ruby (generated comment with nothing but the text 'TODO'):
   def myFunc() # inline comment
   end
 
+# ------------------------------------------------------------------------------
+
+Given ruby (function without parameters and parentheses):
+  def myFunc # inline comment
+  end
+
+Do (trigger doge):
+  \<C-d>
+
+Expect ruby (generated comment with nothing but the text 'TODO'):
+  # [TODO:description]
+  def myFunc # inline comment
+  end
+
 # ==============================================================================
 # Functions with parameters.
-Given ruby (function with parameters):
 # ==============================================================================
+Given ruby (function with parameters):
   def myFunc(p1, p_2 = some_default_value)
   end
 
@@ -28,6 +42,54 @@ Expect ruby (generated comment with @param tags):
   # @param p1 [[TODO:type]] [TODO:description]
   # @param p_2 [[TODO:type]] [TODO:description]
   def myFunc(p1, p_2 = some_default_value)
+  end
+
+# ------------------------------------------------------------------------------
+
+Given ruby (function with parameters but without parentheses):
+  def myFunc p1, p_2 = some_default_value
+  end
+
+Do (trigger doge):
+  \<C-d>
+
+Expect ruby (generated comment with @param tags):
+  # [TODO:description]
+  # @param p1 [[TODO:type]] [TODO:description]
+  # @param p_2 [[TODO:type]] [TODO:description]
+  def myFunc p1, p_2 = some_default_value
+  end
+
+# ------------------------------------------------------------------------------
+
+Given ruby (function with keyword parameters):
+  def myFunc(p1, p_2: some_default_value)
+  end
+
+Do (trigger doge):
+  \<C-d>
+
+Expect ruby (generated comment with @param tags):
+  # [TODO:description]
+  # @param p1 [[TODO:type]] [TODO:description]
+  # @param p_2 [[TODO:type]] [TODO:description]
+  def myFunc(p1, p_2: some_default_value)
+  end
+
+# ------------------------------------------------------------------------------
+
+Given ruby (function with keyword parameters but without parentheses):
+  def myFunc p1, p_2: some_default_value
+  end
+
+Do (trigger doge):
+  \<C-d>
+
+Expect ruby (generated comment with @param tags):
+  # [TODO:description]
+  # @param p1 [[TODO:type]] [TODO:description]
+  # @param p_2 [[TODO:type]] [TODO:description]
+  def myFunc p1, p_2: some_default_value
   end
 
 # ------------------------------------------------------------------------------

--- a/test/filetypes/ruby/functions.vader
+++ b/test/filetypes/ruby/functions.vader
@@ -3,6 +3,7 @@
 # ==============================================================================
 Given ruby (function without parameters):
   def myFunc() # inline comment
+    val = 1
   end
 
 Do (trigger doge):
@@ -11,12 +12,14 @@ Do (trigger doge):
 Expect ruby (generated comment with nothing but the text 'TODO'):
   # [TODO:description]
   def myFunc() # inline comment
+    val = 1
   end
 
 # ------------------------------------------------------------------------------
 
 Given ruby (function without parameters and parentheses):
   def myFunc # inline comment
+    val = 1
   end
 
 Do (trigger doge):
@@ -25,13 +28,15 @@ Do (trigger doge):
 Expect ruby (generated comment with nothing but the text 'TODO'):
   # [TODO:description]
   def myFunc # inline comment
+    val = 1
   end
 
 # ==============================================================================
 # Functions with parameters.
 # ==============================================================================
 Given ruby (function with parameters):
-  def myFunc(p1, p_2 = some_default_value)
+  def myFunc(p1, p_2 = some_default_value) # inline comment
+    val = 1
   end
 
 Do (trigger doge):
@@ -41,13 +46,15 @@ Expect ruby (generated comment with @param tags):
   # [TODO:description]
   # @param p1 [[TODO:type]] [TODO:description]
   # @param p_2 [[TODO:type]] [TODO:description]
-  def myFunc(p1, p_2 = some_default_value)
+  def myFunc(p1, p_2 = some_default_value) # inline comment
+    val = 1
   end
 
 # ------------------------------------------------------------------------------
 
 Given ruby (function with parameters but without parentheses):
-  def myFunc p1, p_2 = some_default_value
+  def myFunc p1, p_2 = some_default_value # inline comment
+    val = 1
   end
 
 Do (trigger doge):
@@ -57,13 +64,15 @@ Expect ruby (generated comment with @param tags):
   # [TODO:description]
   # @param p1 [[TODO:type]] [TODO:description]
   # @param p_2 [[TODO:type]] [TODO:description]
-  def myFunc p1, p_2 = some_default_value
+  def myFunc p1, p_2 = some_default_value # inline comment
+    val = 1
   end
 
 # ------------------------------------------------------------------------------
 
 Given ruby (function with keyword parameters):
-  def myFunc(p1, p_2: some_default_value)
+  def myFunc(p1, p_2: some_default_value) # inline comment
+    val = 1
   end
 
 Do (trigger doge):
@@ -73,13 +82,15 @@ Expect ruby (generated comment with @param tags):
   # [TODO:description]
   # @param p1 [[TODO:type]] [TODO:description]
   # @param p_2 [[TODO:type]] [TODO:description]
-  def myFunc(p1, p_2: some_default_value)
+  def myFunc(p1, p_2: some_default_value) # inline comment
+    val = 1
   end
 
 # ------------------------------------------------------------------------------
 
 Given ruby (function with keyword parameters but without parentheses):
-  def myFunc p1, p_2: some_default_value
+  def myFunc p1, p_2: some_default_value # inline comment
+    val = 1
   end
 
 Do (trigger doge):
@@ -89,13 +100,15 @@ Expect ruby (generated comment with @param tags):
   # [TODO:description]
   # @param p1 [[TODO:type]] [TODO:description]
   # @param p_2 [[TODO:type]] [TODO:description]
-  def myFunc p1, p_2: some_default_value
+  def myFunc p1, p_2: some_default_value # inline comment
+    val = 1
   end
 
 # ------------------------------------------------------------------------------
 
 Given ruby (function with parameters with a '&' in its name):
-  def each(&block)
+  def each(&block) # inline comment
+    val = 1
   end
 
 Do (trigger doge):
@@ -104,13 +117,15 @@ Do (trigger doge):
 Expect ruby (generated comment with @param tags):
   # [TODO:description]
   # @param block [[TODO:type]] [TODO:description]
-  def each(&block)
+  def each(&block) # inline comment
+    val = 1
   end
 
 # ------------------------------------------------------------------------------
 
 Given ruby (function with paramters containing '*' in its name):
   def parameters (p1,p2=4, *p3, **p4)
+    val = 1
   end
 
 Do (trigger doge):
@@ -123,12 +138,44 @@ Expect ruby (generated comment with @param tags):
   # @param p3 [[TODO:type]] [TODO:description]
   # @param p4 [[TODO:type]] [TODO:description]
   def parameters (p1,p2=4, *p3, **p4)
+    val = 1
+  end
+
+# ------------------------------------------------------------------------------
+
+Given ruby (function with multiline paramters):
+  def parameters ( #inline comment
+    p1,
+    p2=4,
+    *p3,
+    **p4
+  )
+    val = 1
+  end
+
+Do (trigger doge):
+  \<C-d>
+
+Expect ruby (generated comment with @param tags):
+  # [TODO:description]
+  # @param p1 [[TODO:type]] [TODO:description]
+  # @param p2 [[TODO:type]] [TODO:description]
+  # @param p3 [[TODO:type]] [TODO:description]
+  # @param p4 [[TODO:type]] [TODO:description]
+  def parameters ( #inline comment
+    p1,
+    p2=4,
+    *p3,
+    **p4
+  )
+    val = 1
   end
 
 # ------------------------------------------------------------------------------
 
 Given ruby (function with paramters containing '*' in its name and without parentheses):
   def parameters p1,p2=4, *p3, **p4
+    val = 1
   end
 
 Do (trigger doge):
@@ -141,12 +188,14 @@ Expect ruby (generated comment with @param tags):
   # @param p3 [[TODO:type]] [TODO:description]
   # @param p4 [[TODO:type]] [TODO:description]
   def parameters p1,p2=4, *p3, **p4
+    val = 1
   end
 
 # ------------------------------------------------------------------------------
 
 Given ruby (function with paramters containing ':' in its name):
   def myFunc (format = :html)
+    val = 1
   end
 
 Do (trigger doge):
@@ -156,6 +205,7 @@ Expect ruby (generated comment with @param tags):
   # [TODO:description]
   # @param format [[TODO:type]] [TODO:description]
   def myFunc (format = :html)
+    val = 1
   end
 
 # ==============================================================================

--- a/test/filetypes/ruby/functions.vader
+++ b/test/filetypes/ruby/functions.vader
@@ -93,7 +93,13 @@ Given ruby (function with keyword parameters but without parentheses):
     val = 1
   end
 
+  def myFunc p1, p_2: # inline comment
+    val = 1
+  end
+
 Do (trigger doge):
+  \<C-d>
+  :8\<CR>
   \<C-d>
 
 Expect ruby (generated comment with @param tags):
@@ -101,6 +107,13 @@ Expect ruby (generated comment with @param tags):
   # @param p1 [[TODO:type]] [TODO:description]
   # @param p_2 [[TODO:type]] [TODO:description]
   def myFunc p1, p_2: some_default_value # inline comment
+    val = 1
+  end
+
+  # [TODO:description]
+  # @param p1 [[TODO:type]] [TODO:description]
+  # @param p_2 [[TODO:type]] [TODO:description]
+  def myFunc p1, p_2: # inline comment
     val = 1
   end
 


### PR DESCRIPTION
# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

Fix ruby function without parentheses

And I let `parameters.match` support the use of arrays because using one regular expression can't satisfy my needs.

And I let `l:curr_line_raw` contains the `\n` because ruby needs to determine if there is a `\n`.

https://github.com/weirongxu/vim-doge/blob/4c43cd41cf5b099b93225a3e2616f2544d639a6e/autoload/doge/pattern.vim#L29