### PR TITLE
feat: Added the Outputs part to type sh

### DIFF
--- a/ftplugin/sh.vim
+++ b/ftplugin/sh.vim
@@ -54,6 +54,8 @@ call doge#buffer#register_doc_standard('google', [
 \      '# \t!var-name',
 \      '# Arguments:',
 \      '# \t$1: !description',
+\      '# Outputs:',
+\      '# \t!description',
 \      '# Returns:',
 \      '# \t!description',
 \      '################################################################################',

--- a/playground/test.sh
+++ b/playground/test.sh
@@ -6,6 +6,8 @@
 #   [TODO:var-name]
 # Arguments:
 #   $1: [TODO:description]
+# Outputs:
+#   [TODO:description]
 # Returns:
 #   [TODO:description]
 ################################################################################
@@ -19,9 +21,26 @@ function test {
 #   [TODO:var-name]
 # Arguments:
 #   $1: [TODO:description]
+# Outputs:
+#   [TODO:description]
 # Returns:
 #   [TODO:description]
 ################################################################################
 test() {
+  print "foobar"
+}
+
+################################################################################
+# [TODO:description]
+# Globals:
+#   [TODO:var-name]
+# Arguments:
+#   $1: [TODO:description]
+# Outputs:
+#   [TODO:description]
+# Returns:
+#   [TODO:description]
+################################################################################
+function test() {
   print "foobar"
 }

--- a/test/filetypes/sh/functions.vader
+++ b/test/filetypes/sh/functions.vader
@@ -16,9 +16,9 @@ Given sh (regular functions):
 
 Do (trigger doge):
   \<C-d>
-  :14\<CR>
+  :16\<CR>
   \<C-d>
-  :27\<CR>
+  :31\<CR>
   \<C-d>
 
 Expect sh (generated comments with a descriptios and 'Globals', 'Arguments' and 'Returns' keywords):
@@ -28,6 +28,8 @@ Expect sh (generated comments with a descriptios and 'Globals', 'Arguments' and 
   #   [TODO:var-name]
   # Arguments:
   #   $1: [TODO:description]
+  # Outputs:
+  #   [TODO:description]
   # Returns:
   #   [TODO:description]
   ################################################################################
@@ -41,6 +43,8 @@ Expect sh (generated comments with a descriptios and 'Globals', 'Arguments' and 
   #   [TODO:var-name]
   # Arguments:
   #   $1: [TODO:description]
+  # Outputs:
+  #   [TODO:description]
   # Returns:
   #   [TODO:description]
   ################################################################################
@@ -54,6 +58,8 @@ Expect sh (generated comments with a descriptios and 'Globals', 'Arguments' and 
   #   [TODO:var-name]
   # Arguments:
   #   $1: [TODO:description]
+  # Outputs:
+  #   [TODO:description]
   # Returns:
   #   [TODO:description]
   ################################################################################


### PR DESCRIPTION
# Prelude

- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

If you don't mind, let me add an Output section to the documents of file type sh.
Google's styleguide has an Output section.
Currently, vim-doge does not have an Output section.
Merging this Pull Request will add the Output section.