### PR TITLE
feat(python): add Google style without types

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Here is the full list of available doc standards per filetype:
 
 | Variable                           | Default             | Supported                                                                                                                                    |
 | :--------------------------------- | :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------- |
-| `g:doge_doc_standard_python`       | `'reST'`            | `'reST'`, `'numpy'`, `'google'`, `'sphinx'`                                                                                                  |
+| `g:doge_doc_standard_python`       | `'reST'`            | `'reST'`, `'numpy'`, `'google'`, `'google_no_types'`, `'sphinx'`                                                                              |
 | `g:doge_doc_standard_php`          | `'phpdoc'`          | `'phpdoc'`                                                                                                                                   |
 | `g:doge_doc_standard_javascript`   | `'jsdoc'`           | `'jsdoc'`                                                                                                                                    |
 | `g:doge_doc_standard_typescript`   | `'jsdoc'`           | `'jsdoc'`                                                                                                                                    |

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -148,5 +148,25 @@ call doge#buffer#register_doc_standard('google', [
 \  }),
 \])
 
+call doge#buffer#register_doc_standard('google_no_types', [
+\  doge#helpers#deepextend(s:function_and_class_method_pattern, {
+\    'parameters': {
+\      'format': '{name}: !description',
+\    },
+\    'template': [
+\      '"""!summary',
+\      '',
+\      '!description',
+\      '%(parameters|)%',
+\      '%(parameters|Args:)%',
+\      '%(parameters|\t{parameters})%',
+\      '%(returnType|)%',
+\      '%(returnType|Returns:)%',
+\      '%(returnType|\t!description)%',
+\      '"""',
+\    ],
+\  }),
+\])
+
 let &cpoptions = s:save_cpo
 unlet s:save_cpo

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -23,6 +23,7 @@ let b:doge_supported_doc_standards = doge#buffer#get_supported_doc_standards([
       \ 'reST',
       \ 'numpy',
       \ 'google',
+      \ 'google_no_types',
       \ 'sphinx',
       \ ])
 let b:doge_doc_standard = doge#buffer#get_doc_standard('python')

--- a/test/filetypes/python/functions-doc-google-no-types.vader
+++ b/test/filetypes/python/functions-doc-google-no-types.vader
@@ -1,0 +1,91 @@
+# ==============================================================================
+# Functions using the Google_no_types doc standard without types.
+# ==============================================================================
+Given python(function without paramters without return type where b:doge_doc_standard='google_no_types'):
+  def myFunc():
+    pass
+
+
+Do (trigger doge):
+  :let b:doge_doc_standard='google_no_types'\<CR>
+  \<C-d>
+
+Expect python (generated comment with nothing but the summary and description 'TODO'):
+  def myFunc():
+    """[TODO:summary]
+
+    [TODO:description]
+    """
+    pass
+
+# ------------------------------------------------------------------------------
+
+Given python(function with parameters without type hints without return type where b:doge_doc_standard='google_no_types'):
+  def myFunc(p1, p2, p3 = ''):
+    pass
+
+Do (trigger doge):
+  :let b:doge_doc_standard='google_no_types'\<CR>
+  \<C-d>
+
+Expect python (generated comment with Args tags):
+  def myFunc(p1, p2, p3 = ''):
+    """[TODO:summary]
+
+    [TODO:description]
+
+    Args:
+      p1: [TODO:description]
+      p2: [TODO:description]
+      p3: [TODO:description]
+    """
+    pass
+
+# ------------------------------------------------------------------------------
+
+Given python(function with parameters with type hints without return type where b:doge_doc_standard='google_no_types'):
+  def myFunc(p1, p2: Callable[[int], None], p3: Callable[[int, Exception], None] = []):
+    pass
+
+Do (trigger doge):
+  :let b:doge_doc_standard='google_no_types'\<CR>
+  \<C-d>
+
+Expect python (generated comment with Args tags):
+  def myFunc(p1, p2: Callable[[int], None], p3: Callable[[int, Exception], None] = []):
+    """[TODO:summary]
+
+    [TODO:description]
+
+    Args:
+      p1: [TODO:description]
+      p2: [TODO:description]
+      p3: [TODO:description]
+    """
+    pass
+
+# ------------------------------------------------------------------------------
+
+Given python(function with parameters with type hints with return type where b:doge_doc_standard='google_no_types'):
+  def myFunc(p1, p2: Callable[[int], None], p3: Callable[[int, Exception], None] = []) -> Sequence[T]:
+    pass
+
+Do (trigger doge):
+  :let b:doge_doc_standard='google_no_types'\<CR>
+  \<C-d>
+
+Expect python (generated comment with Args and Returns tags):
+  def myFunc(p1, p2: Callable[[int], None], p3: Callable[[int, Exception], None] = []) -> Sequence[T]:
+    """[TODO:summary]
+
+    [TODO:description]
+
+    Args:
+      p1: [TODO:description]
+      p2: [TODO:description]
+      p3: [TODO:description]
+
+    Returns:
+      [TODO:description]
+    """
+    pass


### PR DESCRIPTION
# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

It adds a Python style in which type annotations present in the function declaration are not duplicated in the docstring. It closes #97.
