### PR TITLE
Windows support for install script

### DIFF
--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -203,6 +203,12 @@ function! doge#install() abort
   let l:args = !empty(l:langs) ? l:langs : l:languages
   echo '[DoGe] Installing parsers: ' . join(l:args, ', ')
   call execute('!' . g:doge_dir . '/install.sh ' . join(l:args, ' '))
+  if has('win32')
+    let l:install_script = 'install.bat'
+  else
+    let l:install_script = 'install.sh'
+  endif
+  execute('!' . g:doge_dir . '/' . l:install_script . ' ' . join(l:args, ' '))
 endfunction
 
 let &cpoptions = s:save_cpo

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,27 @@
+@echo off
+set ROOT_DIR=%~dp0
+cd %ROOT_DIR%
+
+set packages=
+
+:gen_package_names
+if [%1]==[] goto package_names_ready
+  set package_name=tree-sitter-%1
+  @echo Preparing to install package: %package_name%
+  set packages=%packages% %package_name%
+  shift
+goto gen_package_names
+
+:package_names_ready
+if exist .\node_modules\ goto install_packages
+  call npm i --only=production --no-save
+
+:install_packages
+if "%packages%"=="" goto run_build
+  call npm i --no-save %packages%
+
+:run_build
+if exist .\dist\index.js goto done
+  call npm run build
+
+:done


### PR DESCRIPTION
# Prelude

Thank you for helping out DoGe!

By contributing to DoGe you agree to the following statements **(Replace `[ ]` with `[x]` with those you agree with)**:
- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

Installing tree-sitter using the "install.sh" script only works on linux, this PR adds a windows-compatible "install.bat" script and calls that one from the "doge#install()" function if it detects vim is running on a windows system.
