### PR TITLE
fix(pattern): create custom doc only in valid rtp's

### DIFF
--- a/autoload/doge/pattern.vim
+++ b/autoload/doge/pattern.vim
@@ -184,17 +184,20 @@ function! doge#pattern#custom(name) abort
   " otherwise create a new file with an appropriate path.
   let l:path = ''
   for l:p in ['~/.vim', '~/vimfiles']
-    if isdirectory(expand(l:p))
-      let l:path = expand(l:p)
+    let l:p = expand(l:p)
+    if match(&runtimepath, l:p) >= 0
+      let l:path = l:p
       break
     endif
   endfor
-  if has('nvim') && empty(l:path)
-    let l:path = stdpath('config')
+  if empty(l:path)
+    if exists('*stdpath')
+      let l:path = stdpath('config')
+    else
+      let l:path = getcwd()
+    endif
   endif
-  if !empty(l:path)
-    let l:path .= '/after/ftplugin/' . l:this_ft . '.vim'
-  endif
+  let l:path .= '/after/ftplugin/' . l:this_ft . '.vim'
   if filereadable(l:path)
     let l:cmd = &showtabline ? 'tabedit' : 'split'
     call execute(l:cmd . fnameescape(l:path), 'silent!')
@@ -204,9 +207,7 @@ function! doge#pattern#custom(name) abort
   else
     call execute(&showtabline ? 'tabnew' : 'new', 'silent!')
     setfiletype vim
-    if !empty(l:path)
-      call execute('file ' . fnameescape(l:path), 'silent!')
-    endif
+    call execute('file ' . fnameescape(l:path), 'silent!')
   endif
 
   " Generate the template and paste it at the top of the file.

--- a/test/commands/create-doc-standard.vader
+++ b/test/commands/create-doc-standard.vader
@@ -5,6 +5,9 @@
 # ==============================================================================
 
 Execute (Create a new doc standard based on phpdoc, setup dummy pattern and execute the DogeCreateDocStandard command):
+  if !has('nvim')
+    let &runtimepath .= ',' . expand('~/.vim')
+  endif
   enew
   setfiletype php
   let b:doge_patterns = {
@@ -48,7 +51,15 @@ Execute (Create a new doc standard based on phpdoc, setup dummy pattern and exec
   DogeCreateDocStandard phpdoc
 
 Then (Expect a file to be created with specific content):
-  AssertEqual expand('~/.vim/after/ftplugin/php.vim'), expand('%:p')
+  let b:path = '/after/ftplugin/php.vim'
+  if !has('nvim')
+    let b:path = '~/.vim' . b:path
+  elseif exists('*stdpath')
+    let b:path = '~/.config/nvim' . b:path
+  else
+    let b:path = getcwd() . b:path
+  endif
+  AssertEqual expand(b:path), expand('%:p')
 
   let b:content = join([
   \  '" Preserve existing doge settings.',
@@ -81,16 +92,27 @@ Then (Expect a file to be created with specific content):
   AssertEqual b:content, join(getline(line('^'), line('$')), "\n")
   unlet b:content
 # Remove the buffer to ensure every test will create a new doc standard file.
-  call delete(expand('~/.vim/after/ftplugin/php.vim'))
+  call delete(expand(b:path))
   bdelete!
 
 Execute (Create a new doc standard for an unsupported filetype, setup dummy pattern and execute the DogeCreateDocStandard command):
+  if !has('nvim')
+    let &runtimepath .= ',' . expand('~/.vim')
+  endif
   enew
   setfiletype foo
   DogeCreateDocStandard foo
 
 Then (Expect a file to be created with specific content):
-  AssertEqual expand('~/.vim/after/ftplugin/foo.vim'), expand('%:p')
+  let b:path = '/after/ftplugin/foo.vim'
+  if !has('nvim')
+    let b:path = '~/.vim' . b:path
+  elseif exists('*stdpath')
+    let b:path = '~/.config/nvim' . b:path
+  else
+    let b:path = getcwd() . b:path
+  endif
+  AssertEqual expand(b:path), expand('%:p')
 
   let b:content = join([
   \  '" Preserve existing doge settings.',
@@ -123,5 +145,5 @@ Then (Expect a file to be created with specific content):
   AssertEqual b:content, join(getline(line('^'), line('$')), "\n")
   unlet b:content
 # Remove the buffer to ensure every test will create a new doc standard file.
-  call delete(expand('~/.vim/after/ftplugin/foo.vim'))
+  call delete(expand(b:path))
   bdelete!


### PR DESCRIPTION
# Prelude

By contributing to DoGe you agree to the following statements
- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

Accidently closed the previous one #104. This is the replacement.

<hr />

This handles the special case, when .vim runtimepaths are lying around
on the system, but are not added in the runtimepath of the running
(neo)vim instances itself.

I had a `~/.vim` folder lying around in my system. 
Executing `:DogeCreateDocStandard ...` opened `~/.vim/after/ftplugin/...`, 
I use neovim and the `~/.vim` folder is no longer included in my runtimepath setup,
so I added this check. 