### PR TITLE
docs(contributing): use square brackets for template property

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,13 +176,13 @@ let b:doge_patterns = {
 
         " The 'template' key is a new line when rendering the comment.
         " All the root-level tokens returned from the parser can be used here.
-\       'template': {
+\       'template': [
 \         '/**',
 \         ' * !description',
 \         '%(parameters| *)%',
 \         '%(parameters| * {parameters})%',
 \         ' */',
-\       },
+\       ],
 \     }
 \  ],
 \}


### PR DESCRIPTION
# Prelude

Thank you for helping out DoGe!

<!--
Replace [ ] with [x] with those you agree with.
-->

By contributing to DoGe you agree to the following statements:

- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

Just to avoid the confusion of having the curly brackets there :slightly_smiling_face: 
