### PR TITLE
Remove colon after return types in numpy doc (#308)

### DIFF
--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -113,7 +113,7 @@ call doge#buffer#register_doc_standard('numpy', [
 \      '%(returnType|)%',
 \      '%(returnType|Returns)%',
 \      '%(returnType|-------)%',
-\      '%(returnType|{returnType}:)%',
+\      '%(returnType|{returnType})%',
 \      '%(returnType|\t!description)%',
 \      '%(exceptions|)%',
 \      '%(exceptions|Raises)%',

--- a/test/filetypes/python/functions-doc-numpy.vader
+++ b/test/filetypes/python/functions-doc-numpy.vader
@@ -71,7 +71,7 @@ Expect python (generated comment with Parameters and Returns tag):
 
     Returns
     -------
-    Sequence[T]:
+    Sequence[T]
       [TODO:description]
     """
     pass


### PR DESCRIPTION
fixes #308 