### PR TITLE
Fix Expansion from the middle of multiline defs

### DIFF
--- a/autoload/doge/pattern.vim
+++ b/autoload/doge/pattern.vim
@@ -95,11 +95,11 @@ function! doge#pattern#generate(pattern) abort
     let l:comment_lnum_insert_position = line('.')
   else
     let l:comment_indent = 0
-	" Search for find empty (whitespace-only) line above.
-	let l:insert_l = line('.')
-	while (l:insert_l > 0) && getline(l:insert_l) !~ '^\s*$'
-		let l:insert_l -= 1
-	endw
+    " Search for find empty (whitespace-only) line above.
+    let l:insert_l = line('.')
+    while (l:insert_l > 0) && getline(l:insert_l) !~ '^\s*$'
+      let l:insert_l -= 1
+    endw
     let l:comment_lnum_insert_position = l:insert_l
   endif
 

--- a/autoload/doge/pattern.vim
+++ b/autoload/doge/pattern.vim
@@ -95,7 +95,12 @@ function! doge#pattern#generate(pattern) abort
     let l:comment_lnum_insert_position = line('.')
   else
     let l:comment_indent = 0
-    let l:comment_lnum_insert_position = line('.') - 1
+	" Search for find empty (whitespace-only) line above.
+	let l:insert_l = line('.')
+	while (l:insert_l > 0) && getline(l:insert_l) !~ '^\s*$'
+		let l:insert_l -= 1
+	endw
+    let l:comment_lnum_insert_position = l:insert_l
   endif
 
   try


### PR DESCRIPTION
# Prelude

Thank you for helping out DoGe!

<!--
Replace [ ] with [x] with those you agree with.
-->

By contributing to DoGe you agree to the following statements:

- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

Expanding multi-line definitions only works correctly if the cursor is already on the first line. I work with C++ where definitions often span multiple lines due to templates or long return values and either I have to force myself to move the cursor to the first line or I get misplaced docstring.

Currently this

    template<typename T>
    long_return_type
    foo(); <--- Cursor

expands into

    template<typename T>
    long_return_type
    /* DOCSTRING */
    foo();

instead of this

    /* DOCSTRING */
    template<typename T>
    long_return_type
    foo();

So I made a small change which inserts the docstring on the first empty line instead of the fixed -1 offset.

I am not quite sure where should I make any tests for this, please let me know and I will try to add them.