### PR TITLE
Windows build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: Release
 on:
-  workflow_dispatch:
   release:
     types: [created]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - run: npm config set msvs_version 2022 --global
       - run: npm ci --no-save --verbose
       - name: Build Unix binary
         if: matrix.target != 'win'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - run: npm config ls -l | grep nodedir
       - run: rm -rf $HOME/.node-gyp
       - run: npm i --force --no-save --verbose
       - name: Build Unix binary

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci --no-save --verbose
+      - run: npm i --force --no-save --verbose
       - name: Build Unix binary
         if: matrix.target != 'win'
         run: npm run build:binary:unix

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: rm -rf $HOME/.node-gyp
+      - run: Remove-Item -path $HOME/.node-gyp -recurse -force
       - run: npm i --force --no-save --verbose
       - name: Build Unix binary
         if: matrix.target != 'win'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ jobs:
         # os: [macos-latest, ubuntu-latest]
         os: [windows-latest]
         # vim-version: [v7.4.2119, v8.2.5172]
-        vim-version: [v7.4.2119]
+        vim-version: [v8.2.5172]
         # node-version: [12, 16]
-        node-version: [10]
+        node-version: [16]
         include:
           # - os: macos-latest
           #   target: macos

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         # vim-version: [v7.4.2119, v8.2.5172]
         vim-version: [v8.2.5172]
         # node-version: [12, 16]
-        node-version: [20]
+        node-version: [18]
         include:
           # - os: macos-latest
           #   target: macos

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,12 @@ jobs:
     strategy:
       matrix:
         # os: [macos-latest, ubuntu-latest, windows-latest]
-        os: [macos-latest, ubuntu-latest]
-        vim-version: [v7.4.2119, v8.2.5172]
-        node-version: [12, 16]
+        # os: [macos-latest, ubuntu-latest]
+        os: [windows-latest]
+        # vim-version: [v7.4.2119, v8.2.5172]
+        vim-version: [v8.2.5172]
+        # node-version: [12, 16]
+        node-version: [16]
         include:
           - os: macos-latest
             target: macos
@@ -56,51 +59,51 @@ jobs:
         run: ./scripts/run-vader-tests.sh "${{ steps.vim.outputs.executable }}"
         shell: bash
 
-  tests_neovim:
-    name: NeoVim
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest]
-        vim-version: [v0.3.2, head]
-        node-version: [12, 16]
-        include:
-          - os: macos-latest
-            target: macos
-          - os: ubuntu-latest
-            target: linux
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout kkoomen/vim-doge
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Checkout junegunn/vader.vim
-        uses: actions/checkout@v2
-        with:
-          repository: junegunn/vader.vim
-          path: vader.vim
-      - name: Setup nodejs
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm ci --no-save --verbose
-      - name: Build binary
-        run: npm run build:binary:unix
-      - name: Setup neovim
-        uses: thinca/action-setup-vim@v1
-        id: vim
-        with:
-          vim_version: ${{ matrix.vim-version }}
-          vim_type: neovim
-      - name: Run tests
-        run: ./scripts/run-vader-tests.sh "${{ steps.vim.outputs.executable }}"
-        shell: bash
-
-  vint:
-    name: Linter
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-      - run: pip install vim-vint
-      - run: vint -s ./autoload ./plugin
+  # tests_neovim:
+  #   name: NeoVim
+  #   strategy:
+  #     matrix:
+  #       os: [macos-latest, ubuntu-latest]
+  #       vim-version: [v0.3.2, head]
+  #       node-version: [12, 16]
+  #       include:
+  #         - os: macos-latest
+  #           target: macos
+  #         - os: ubuntu-latest
+  #           target: linux
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - name: Checkout kkoomen/vim-doge
+  #       uses: actions/checkout@v2
+  #       with:
+  #         submodules: true
+  #     - name: Checkout junegunn/vader.vim
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: junegunn/vader.vim
+  #         path: vader.vim
+  #     - name: Setup nodejs
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #     - run: npm ci --no-save --verbose
+  #     - name: Build binary
+  #       run: npm run build:binary:unix
+  #     - name: Setup neovim
+  #       uses: thinca/action-setup-vim@v1
+  #       id: vim
+  #       with:
+  #         vim_version: ${{ matrix.vim-version }}
+  #         vim_type: neovim
+  #     - name: Run tests
+  #       run: ./scripts/run-vader-tests.sh "${{ steps.vim.outputs.executable }}"
+  #       shell: bash
+  #
+  # vint:
+  #   name: Linter
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-python@v1
+  #     - run: pip install vim-vint
+  #     - run: vint -s ./autoload ./plugin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         # vim-version: [v7.4.2119, v8.2.5172]
         vim-version: [v8.2.5172]
         # node-version: [12, 16]
-        node-version: [16]
+        node-version: [14]
         include:
           # - os: macos-latest
           #   target: macos
@@ -42,8 +42,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install -g node-gyp@latest
-      - run: npm i --force --no-save --verbose
+      - run: npm ci --no-save --verbose
       - name: Build Unix binary
         if: matrix.target != 'win'
         run: npm run build:binary:unix

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm config ls -l | grep nodedir
       - run: rm -rf $HOME/.node-gyp
       - run: npm i --force --no-save --verbose
       - name: Build Unix binary

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         # vim-version: [v7.4.2119, v8.2.5172]
         vim-version: [v8.2.5172]
         # node-version: [12, 16]
-        node-version: [14]
+        node-version: [20]
         include:
           # - os: macos-latest
           #   target: macos
@@ -42,7 +42,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm config set msvs_version 2022 --global
       - run: npm ci --no-save --verbose
       - name: Build Unix binary
         if: matrix.target != 'win'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: Remove-Item -path $HOME/.node-gyp -recurse -force
+      - run: npm install -g node-gyp@latest
       - run: npm i --force --no-save --verbose
       - name: Build Unix binary
         if: matrix.target != 'win'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - run: rm -rf $HOME/.node-gyp
       - run: npm i --force --no-save --verbose
       - name: Build Unix binary
         if: matrix.target != 'win'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,12 +21,12 @@ jobs:
         # node-version: [12, 16]
         node-version: [16]
         include:
-          - os: macos-latest
-            target: macos
-          - os: ubuntu-latest
-            target: linux
-          # - os: windows-latest
-            # target: win
+          # - os: macos-latest
+          #   target: macos
+          # - os: ubuntu-latest
+          #   target: linux
+          - os: windows-latest
+            target: win
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout kkoomen/vim-doge

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ jobs:
         # os: [macos-latest, ubuntu-latest]
         os: [windows-latest]
         # vim-version: [v7.4.2119, v8.2.5172]
-        vim-version: [v8.2.5172]
+        vim-version: [v7.4.2119]
         # node-version: [12, 16]
-        node-version: [18]
+        node-version: [10]
         include:
           # - os: macos-latest
           #   target: macos


### PR DESCRIPTION
Since the [v3.12.0 release](https://github.com/kkoomen/vim-doge/releases/tag/v3.12.0) the windows build has been removed due to node-gyp building issues.

Potential cause(s):
- https://github.com/nodejs/node-gyp/issues/2627