### PR TITLE
Dynamic JS/TS return types

### DIFF
--- a/test/filetypes/javascript/es6.vader
+++ b/test/filetypes/javascript/es6.vader
@@ -11,7 +11,6 @@ Expect javascript (no generated comment):
   /**
    * [TODO:description]
    *
-   * @returns {[TODO:type]} [TODO:description]
    */
   () => {}
 
@@ -47,7 +46,7 @@ Given javascript (fat-arrow function with parameters without type hints using 'c
 
 Do (trigger doge):
   \<C-d>
-  :13\<CR>
+  :12\<CR>
   \<C-d>
 
 Expect javascript (generated comment with @param and @returns tags):
@@ -58,7 +57,6 @@ Expect javascript (generated comment with @param and @returns tags):
    * @param {[TODO:type]} [p2] - [TODO:description]
    * @param {[TODO:type]} p3 - [TODO:description]
    * @param {[TODO:type]} p4 - [TODO:description]
-   * @returns {[TODO:type]} [TODO:description]
    */
   const myFunc = ($p1 = 'value', p2 = [], p3, p4) => {}
 
@@ -69,7 +67,6 @@ Expect javascript (generated comment with @param and @returns tags):
    * @param {[TODO:type]} [p2] - [TODO:description]
    * @param {[TODO:type]} p3 - [TODO:description]
    * @param {[TODO:type]} p4 - [TODO:description]
-   * @returns {[TODO:type]} [TODO:description]
    */
   let myFunc = ($p1 = 'value', p2 = [], p3, p4) => {}
 
@@ -238,6 +235,6 @@ Expect javascript (generated comment with @async, @function, @param and @returns
    * @async
    * @param {string} $p1 - [TODO:description]
    * @param {Foo | Bar | Baz} p2 - [TODO:description]
-   * @returns {(Foo | Bar)} [TODO:description]
+   * @returns {Promise<(Foo | Bar)>} [TODO:description]
    */
   const myFunc = async ($p1: string, p2: Foo | Bar | Baz): (Foo | Bar) => {};

--- a/test/filetypes/javascript/functions-inside-objects.vader
+++ b/test/filetypes/javascript/functions-inside-objects.vader
@@ -79,7 +79,7 @@ Expect javascript (generated comment with @async, @param and @returns tags):
      * @param {array} [p2] - [TODO:description]
      * @param {[TODO:type]} p3 - [TODO:description]
      * @param {[TODO:type]} p4 - [TODO:description]
-     * @returns {( 1 | 2 | 3 )} [TODO:description]
+     * @returns {Promise<( 1 | 2 | 3 )>} [TODO:description]
      */
     'my-arrow-func': async ($p1: string = 'value', p2: array = [], p3, p4 /* inline comment */): ( 1 | 2 | 3 ) => {
       //

--- a/test/filetypes/javascript/functions.vader
+++ b/test/filetypes/javascript/functions.vader
@@ -11,7 +11,6 @@ Expect javascript (generated comment with a description and a @returns tag):
   /**
    * [TODO:description]
    *
-   * @returns {[TODO:type]} [TODO:description]
    */
   function myFunc(/* inline comment */) {}
 
@@ -32,7 +31,6 @@ Expect javascript (generated comment with a description, @param and @returns tag
    * @param {[TODO:type]} [p2] - [TODO:description]
    * @param {[TODO:type]} p3 - [TODO:description]
    * @param {[TODO:type]} p4 - [TODO:description]
-   * @returns {[TODO:type]} [TODO:description]
    */
   function myFunc($p1 = 'value', p2 = [], p3, p4 /* inline comment */) {}
 
@@ -74,7 +72,6 @@ Expect javascript (generated comment with @functon and @param tags):
    * @param {[TODO:type]} [p2] - [TODO:description]
    * @param {[TODO:type]} p3 - [TODO:description]
    * @param {[TODO:type]} p4 - [TODO:description]
-   * @returns {[TODO:type]} [TODO:description]
    */
   var myFunc = function($p1 = 'value', p2 = [], p3, p4) {}
 
@@ -130,7 +127,6 @@ Do (trigger doge):
   /**
    * [TODO:description]
    *
-   * @returns {[TODO:type]} [TODO:description]
    */
   Person.prototype.greet = function () {}
 
@@ -193,7 +189,6 @@ Expect javascript (generated comment with a description, @param and @returns tag
    * @param {[TODO:type]} [p2] - [TODO:description]
    * @param {[TODO:type]} p3 - [TODO:description]
    * @param {[TODO:type]} p4 - [TODO:description]
-   * @returns {[TODO:type]} [TODO:description]
    */
   function* myFunc($p1 = 'value', p2 = [], p3, p4) {}
 
@@ -229,7 +224,6 @@ Expect javascript (generated comment with @async, @param and @returns tags):
    *
    * @generator
    * @param {[TODO:type]} p1 - [TODO:description]
-   * @returns {[TODO:type]} [TODO:description]
    */
   var perfectSquares = function*(p1) {};
 
@@ -326,7 +320,6 @@ Expect javascript (generated comments with a description, @param, @throws and @r
    *
    * @throws {[TODO:name]} - [TODO:description]
    * @throws {CustomException} - [TODO:description]
-   * @returns {[TODO:type]} [TODO:description]
    */
   function test() {
     err = new CustomException();
@@ -348,7 +341,7 @@ Do (trigger doge):
   :1\<CR>
   \<C-d>
   :let g:doge_javascript_settings = {'destructuring_props': 0}\<CR>
-  :13\<CR>
+  :12\<CR>
   \<C-d>
   :let g:doge_javascript_settings = {'destructuring_props': 1}\<CR>
 
@@ -361,7 +354,6 @@ Expect javascript (generated comments with a description, @param and @returns ta
    * @param {str} [TODO:name].b - [TODO:description]
    * @param {[TODO:type]} [[TODO:name].c] - [TODO:description]
    * @param {int} [[TODO:name].d] - [TODO:description]
-   * @returns {[TODO:type]} [TODO:description]
    */
   function foo({ a, b: str, c = 3, d: int = 5 }) {}
 
@@ -369,7 +361,6 @@ Expect javascript (generated comments with a description, @param and @returns ta
    * [TODO:description]
    *
    * @param {[TODO:type]} [TODO:name] - [TODO:description]
-   * @returns {[TODO:type]} [TODO:description]
    */
   function foo({ a, b: str, c = 3, d: int = 5 }) {}
 

--- a/test/filetypes/typescript/class-methods.vader
+++ b/test/filetypes/typescript/class-methods.vader
@@ -18,7 +18,7 @@ Given typescript (functions with destructured parameters):
 Do (trigger doge):
   :4\<CR>
   \<C-d>
-  :18\<CR>
+  :17\<CR>
   \<C-d>
 
 Expect typescript (generated comment with a description, @param and @returns tags):
@@ -32,7 +32,6 @@ Expect typescript (generated comment with a description, @param and @returns tag
      * @param {boolean} [p2] - [TODO:description]
      * @param {[TODO:type]} [p3] - [TODO:description]
      * @param {[TODO:type]} [p4] - [TODO:description]
-     * @returns {[TODO:type]} [TODO:description]
      */
     @Test()
     @Test()
@@ -50,7 +49,7 @@ Expect typescript (generated comment with a description, @param and @returns tag
      * @param {[TODO:type]} [p4] - [TODO:description]
      * @throws {[TODO:name]} - [TODO:description]
      * @throws {CustomException} - [TODO:description]
-     * @returns {UserA & UserB} [TODO:description]
+     * @returns {Promise<UserA & UserB>} [TODO:description]
      */
     @Test()
     async test(@Body() { idUser, userModel }: { error: string } & { idUser: ObjectId, userModel: string }, p2?: boolean, p3?, p4 = false): UserA & UserB {
@@ -82,7 +81,6 @@ Expect typescript (generated comment with a description, @param and @returns tag
      *
      * @param {Model<T>} $model - [TODO:description]
      * @param {Model<T>} model - [TODO:description]
-     * @returns {[TODO:type]} [TODO:description]
      */
     constructor(
       @InjectModel(User.name) private readonly $model: Model<T>,

--- a/test/filetypes/typescript/generics.vader
+++ b/test/filetypes/typescript/generics.vader
@@ -124,7 +124,7 @@ Expect typescript (generated comment with @async, @template, @param and @returns
    * @template R - [TODO:description]
    * @param {(...args: any[]) => R} fn1 - [TODO:description]
    * @param {Array<(a: R) => R>} fns - [TODO:description]
-   * @returns {(a: R) => R} [TODO:description]
+   * @returns {Promise<(a: R) => R>} [TODO:description]
    */
   export const pipe = async <R>(
     fn1: (...args: any[]) => R,

--- a/test/filetypes/typescript/return-types.vader
+++ b/test/filetypes/typescript/return-types.vader
@@ -1,0 +1,176 @@
+# ==============================================================================
+# Functions without parameters.
+# ==============================================================================
+Given javascript (function without params and return type):
+  function myFunc() {}
+
+Do (trigger doge):
+  \<C-d>
+
+Expect javascript (generated comment with only a description):
+  /**
+   * [TODO:description]
+   *
+   */
+  function myFunc() {}
+
+# ==============================================================================
+# Functions without parameters.
+# ==============================================================================
+Given javascript (functions with void, undefined and null return types):
+  function myFunc(): void {}
+  function myFunc(): undefined {}
+  function myFunc(): null {}
+
+Do (trigger doge):
+  \<C-d>
+  :6\<CR>
+  \<C-d>
+  :12\<CR>
+  \<C-d>
+
+Expect javascript (generated comment with a description and a @returns tag for the null type):
+  /**
+   * [TODO:description]
+   *
+   */
+  function myFunc(): void {}
+  /**
+   * [TODO:description]
+   *
+   */
+  function myFunc(): undefined {}
+  /**
+   * [TODO:description]
+   *
+   * @returns {null} [TODO:description]
+   */
+  function myFunc(): null {}
+
+# ==============================================================================
+# Functions without parameters.
+# ==============================================================================
+Given javascript (functions with void and undefined return statement values):
+  function myFunc() {
+    return void 0;
+  }
+
+  const foo = () => {
+    return void(0);
+  }
+
+  function myFunc() {
+    return undefined;
+  }
+
+  const foo = () => {
+    return undefined;
+  }
+
+Do (trigger doge):
+  \<C-d>
+  :9\<CR>
+  \<C-d>
+  :17\<CR>
+  \<C-d>
+  :25\<CR>
+  \<C-d>
+
+Expect javascript (generated comment with only a description):
+  /**
+   * [TODO:description]
+   *
+   */
+  function myFunc() {
+    return void 0;
+  }
+
+  /**
+   * [TODO:description]
+   *
+   */
+  const foo = () => {
+    return void(0);
+  }
+
+  /**
+   * [TODO:description]
+   *
+   */
+  function myFunc() {
+    return undefined;
+  }
+
+  /**
+   * [TODO:description]
+   *
+   */
+  const foo = () => {
+    return undefined;
+  }
+
+# ==============================================================================
+# Functions without parameters.
+# ==============================================================================
+Given javascript (functions with void and undefined return statement values):
+  function myFunc() {
+    return true;
+  }
+
+  const foo = () => {
+    return true;
+  }
+
+  function myFunc() {
+    return true;
+  }
+
+  const foo = () => {
+    return true;
+  }
+
+Do (trigger doge):
+  \<C-d>
+  :10\<CR>
+  \<C-d>
+  :19\<CR>
+  \<C-d>
+  :28\<CR>
+  \<C-d>
+
+Expect javascript (generated comment with only a description):
+  /**
+   * [TODO:description]
+   *
+   * @returns {[TODO:type]} [TODO:description]
+   */
+  function myFunc() {
+    return true;
+  }
+
+  /**
+   * [TODO:description]
+   *
+   * @returns {[TODO:type]} [TODO:description]
+   */
+  const foo = () => {
+    return true;
+  }
+
+  /**
+   * [TODO:description]
+   *
+   * @returns {[TODO:type]} [TODO:description]
+   */
+  function myFunc() {
+    return true;
+  }
+
+  /**
+   * [TODO:description]
+   *
+   * @returns {[TODO:type]} [TODO:description]
+   */
+  const foo = () => {
+    return true;
+  }


### PR DESCRIPTION
Fixes #312 

This PR fixes:
- looks for `return_statement` syntax nodes within the body and adds the `@return` as well if there's no type specific, but a `return_statement` node has been found with neither one of the values: `void(0)`, `void 0` and `undefined`
- some incorrect return types for promise functions