### PR TITLE
fix: avoid redefine command error

### DIFF
--- a/plugin/doge.vim
+++ b/plugin/doge.vim
@@ -201,7 +201,7 @@ endif
 "
 " The string value should point to a doc standard name listed in the
 " `b:doge_supported_doc_standards` variable.
-command -count -nargs=? -complete=customlist,doge#command_complete DogeGenerate call doge#generate(<count> ? <count> : <q-args>)
+command! -count -nargs=? -complete=customlist,doge#command_complete DogeGenerate call doge#generate(<count> ? <count> : <q-args>)
 
 augroup doge
   autocmd!


### PR DESCRIPTION
# Prelude

Thank you for helping out DoGe!

<!--
Replace [ ] with [x] with those you agree with.
-->

By contributing to DoGe you agree to the following statements:

- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

When upgrading pluging, the `plugin/doge.vim` will be executed twice (one for initial load of vim-doge, one for loading upgraded vim-doge). Using `:command` to redefine will cause vimscript error, which can be easily avoided by using `:command!`.
