### PR TITLE
Only replace \t chars when not followed by "param"

### DIFF
--- a/autoload/doge/pattern.vim
+++ b/autoload/doge/pattern.vim
@@ -87,7 +87,7 @@ function! doge#pattern#generate(pattern) abort
     endif
 
     for l:replaced in split(l:line_replaced, "\n")
-      call add(l:comment, substitute(l:replaced, '\C\\t', repeat(' ', shiftwidth()), 'g'))
+      call add(l:comment, substitute(l:replaced, '\\t\(param\)\@!', repeat(' ', shiftwidth()), 'g'))
     endfor
   endfor
 

--- a/test/options/doge_doxygen_settings.vader
+++ b/test/options/doge_doxygen_settings.vader
@@ -144,7 +144,11 @@ Expect c (generated comment):
 # C++ functions and doc standards.
 # ==============================================================================
 Given cpp (cpp function):
-  void append_token(const std::string& text /* inline comment */, const AST_Node* node);
+  template<class F, class... Args>
+  auto Person::getPersonType (const Builder& builder) -> PersonType
+  {
+      return _person_type;
+  }
 
 Do (trigger doge):
   :let b:doge_doc_standard='doxygen_javadoc'\<CR>
@@ -154,10 +158,16 @@ Expect cpp (generated comment):
   /**
    * \brief [TODO:summary]
    *
-   * \param[[TODO:direction]] text [TODO:description]
-   * \param[[TODO:direction]] node [TODO:description]
+   * \tparam F [TODO:description]
+   * \tparam Args [TODO:description]
+   * \param[[TODO:direction]] builder [TODO:description]
+   * \return [TODO:description]
    */
-  void append_token(const std::string& text /* inline comment */, const AST_Node* node);
+  template<class F, class... Args>
+  auto Person::getPersonType (const Builder& builder) -> PersonType
+  {
+      return _person_type;
+  }
 
 Given cpp (function without parameters with return type):
   int myFunc(/* inline comment */) {}


### PR DESCRIPTION
Fixes #574 