### PR TITLE
Now runs in Windows

### DIFF
--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -11,7 +11,8 @@ function! doge#run_parser() abort
   let l:executables = [
         \ '/helper/target/release/vim-doge-helper.exe',
         \ '/helper/target/release/vim-doge-helper',
-        \ '/bin/vim-doge-helper',
+        \ '/bin/vim-doge-helper.exe',
+        \ '/bin/vim-doge-helper'
         \ ]
 
   for l:executable in l:executables


### PR DESCRIPTION
# Prelude

Thank you for helping out vim-doge!

<!--
Replace [ ] with [x] with those you agree with.
-->

By contributing to vim-doge you agree to the following statements:

- [x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?
[This](https://github.com/kkoomen/vim-doge/issues/588) was also an issue for me.

Adding `/bin/vim-doge-helper.exe` to `let l:executables` in the function `doge#run_parser()` resolved the issue.
