### PR TITLE
Fix undo cursor position bug

### DIFF
--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -22,7 +22,7 @@ function! doge#run_parser() abort
       let l:current_line = l:cursor_pos[1]
 
       let l:tempfile = tempname()
-      keepjumps call execute('%!tee ' . l:tempfile, 'silent!')
+      keepjumps call writefile(getline(line('^'), line('$')), l:tempfile)
 
       let l:args = [
             \ '--filepath', l:tempfile,

--- a/test/undo-cursor-pos.vader
+++ b/test/undo-cursor-pos.vader
@@ -1,0 +1,32 @@
+# ==============================================================================
+# Make sure that pressing 'u' after generating a docblock doesn't jump to the 
+# top of the file.
+#
+# See https://github.com/kkoomen/vim-doge/issues/309
+# ==============================================================================
+Given javascript(function):
+  function foo() {
+    //
+  }
+
+  function bar() {
+    //
+  }
+
+Do (trigger doge):
+  :call cursor(5,8)\<CR>
+  \<C-d>
+  u
+
+Expect javascript (no changes):
+  function foo() {
+    //
+  }
+
+  function bar() {
+    //
+  }
+
+Then (the cursor should be at the same pos as before generating the comment):
+  AssertEqual 5, line('.')
+  AssertEqual 8, col('.')


### PR DESCRIPTION
Using `%!tree` will jump the cursor to the top of the file, thus when generated a comment and then pressing `u`, it will jump the cursor back to the top of the file. Using `writefile()` solves the problem.

Fixes #309 