### PR TITLE
handle case when ftplugin is disabled

### DIFF
--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -77,7 +77,7 @@ endfunction
 " arg: Either a count (0 by default) or a string (empty by default).
 function! doge#generate(arg) abort
   if !exists('b:doge_supported_doc_standards')
-    echoerr "[vim-doge] It seems like you forgot to set `filetype plugin on` in your .vimrc"
+    echoerr '[vim-doge] It seems like you forgot to set `filetype plugin on` in your .vimrc'
     return 1
   endif
 

--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -76,6 +76,11 @@ endfunction
 "
 " arg: Either a count (0 by default) or a string (empty by default).
 function! doge#generate(arg) abort
+  if !exists('b:doge_supported_doc_standards')
+    echoerr "[vim-doge] It seems like you forgot to set `filetype plugin on` in your .vimrc"
+    return 1
+  endif
+
   " Immediately validate if the doc standard is allowed.
   if index(b:doge_supported_doc_standards, b:doge_doc_standard) < 0
     echoerr printf(


### PR DESCRIPTION
Additional PR for the case as described in #621 where the user might have disabled `filetype plugin on`. In that case, the `ftplugin/<filetype>.vim` variables won't exist. We could've picked any of the default variables that are always defined in the `ftplugin/<filetype>.vim` folder, so I simply took `b:doge_supported_doc_standards`. If this doesn't exists when `doge#generate` is executing, then we'll print an error message suggesting that it might be that the user did not set `filetype plugin on` in their `.vimrc`.