### PR TITLE
PHP single name use statement case

### DIFF
--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -77,7 +77,7 @@ endfunction
 " arg: Either a count (0 by default) or a string (empty by default).
 function! doge#generate(arg) abort
   if !exists('b:doge_supported_doc_standards')
-    echoerr "[vim-doge] It seems like you forgot to set `filetype plugin on` in your .vimrc"
+    echoerr '[vim-doge] It seems like you forgot to set `filetype plugin on` in your .vimrc'
     return 1
   endif
 

--- a/autoload/doge.vim
+++ b/autoload/doge.vim
@@ -76,6 +76,11 @@ endfunction
 "
 " arg: Either a count (0 by default) or a string (empty by default).
 function! doge#generate(arg) abort
+  if !exists('b:doge_supported_doc_standards')
+    echoerr "[vim-doge] It seems like you forgot to set `filetype plugin on` in your .vimrc"
+    return 1
+  endif
+
   " Immediately validate if the doc standard is allowed.
   if index(b:doge_supported_doc_standards, b:doge_doc_standard) < 0
     echoerr printf(

--- a/test/filetypes/php/functions-with-namespaces.vader
+++ b/test/filetypes/php/functions-with-namespaces.vader
@@ -8,16 +8,20 @@
 
 Given php (function where the type should result in its FQN):
   <?php
+  use Closure;
+  use Exception;
   use Symfony\Component\HttpFoundation\Response;
 
   function myFunction(Response $p1): Response {}
 
 Do (trigger doge):
-  :4\<CR>
+  :6\<CR>
   \<C-d>
 
 Expect php (generated comment containing the FQN):
   <?php
+  use Closure;
+  use Exception;
   use Symfony\Component\HttpFoundation\Response;
 
   /**


### PR DESCRIPTION
Fixes #621, where as the PHP parser only included use statement usages in the form of `use Foo\Bar;` but not `use Foo;`.