### PR TITLE
Ignore member expressions as function param in JS/TS

### DIFF
--- a/helper/src/typescript/parser.rs
+++ b/helper/src/typescript/parser.rs
@@ -177,6 +177,13 @@ impl<'a> TypescriptParser<'a> {
     fn parse_member_expression(&self, node: &Node) -> Result<Map<String, Value>, String> {
         let mut tokens = Map::new();
 
+        // If a member expression is part of a function parameter, ignore it.
+        if let Some(parent_node) = node.parent() {
+            if ["required_parameter", "rest_parameter", "optional_parameter"].contains(&parent_node.kind()) {
+                return Ok(tokens);
+            }
+        }
+
         for child_node in node.children(&mut node.walk()) {
             match child_node.kind() {
                 "member_expression" => {
@@ -301,7 +308,7 @@ impl<'a> TypescriptParser<'a> {
                             tokens.insert("params".to_string(), Value::Array(params));
                         }
                     }
-                }
+                },
                 _ => {},
             }
         }
@@ -372,7 +379,7 @@ impl<'a> TypescriptParser<'a> {
                         subparam.insert("name".to_string(), Value::String(subparam_name));
                         subparam.insert("optional".to_string(), Value::Bool(true));
                     },
-                    "pair_pattern" =>{
+                    "pair_pattern" => {
                         let subparam_name = node
                             .children(&mut node.walk())
                             .next()

--- a/test/filetypes/javascript/functions.vader
+++ b/test/filetypes/javascript/functions.vader
@@ -367,6 +367,28 @@ Expect javascript (generated comments with a description, @param and @returns ta
   function foo({ a, b: str, c = 3, d: int = 5 }) {}
 
 # ==============================================================================
+# Test function references as default values
+# ==============================================================================
+Given javascript (functions with destructuring_props):
+  function foo(bar = import.meta.url) {
+    return true;
+  }
+
+Do (trigger doge):
+  \<C-d>
+
+Expect javascript (generated comments with a description, @param and @returns tags):
+  /**
+   * [TODO:description]
+   *
+   * @param {[TODO:type]} [bar] - [TODO:description]
+   * @returns {[TODO:type]} [TODO:description]
+   */
+  function foo(bar = import.meta.url) {
+    return true;
+  }
+
+# ==============================================================================
 # Test the 'omit_redundant_param_types' option
 # ==============================================================================
 Given javascript (functions where the type should be omitted if let g:doge_javascript_settings = {'omit_redundant_param_types': 1} is set):


### PR DESCRIPTION
Fixes #651