### PR TITLE
Update docs on how to disable default keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,21 @@ useful if your system is read-only or uses immutable datastructures.
 
 Default: `1`
 
-Whether to enable built-in mappings. If you decide to disable this, then you can
+Whether to enable built-in mappings.
+
+To disable:
+```vim
+let g:doge_enable_mappings = 0
+```
+
+Or with lua
+```lua
+-- be sure to call this before the plugin gets loaded.
+-- For example, in LazyVim, call in `init`
+vim.api.nvim_set_var('doge_enable_mappings', 0)
+```
+
+If you decide to disable this, then you can
 copy the mappings below and change them to your needs:
 
 ```vim


### PR DESCRIPTION
By contributing to vim-doge you agree to the following statements:

- [X] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [X] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?
I was having trouble disabling using LazyVim because I was updating the variable in the `config` function. Decided to make it clear that this needs to happen before the plugin gets loaded