### PR TITLE
Enable generation for structs in C#

### DIFF
--- a/helper/src/csharp/docs/xmldoc.yaml
+++ b/helper/src/csharp/docs/xmldoc.yaml
@@ -22,6 +22,7 @@ templates:
 
   other:
     node_types:
+      - struct_declaration
       - class_declaration
       - variable_declaration
       - property_declaration

--- a/helper/src/csharp/parser.rs
+++ b/helper/src/csharp/parser.rs
@@ -41,6 +41,7 @@ impl<'a> CSharpParser<'a> {
                     "constructor_declaration" => Some(self.parse_function(&child_node)),
 
                     "class_declaration" |
+                    "struct_declaration" |
                     "variable_declaration" |
                     "property_declaration" |
                     "field_declaration" |


### PR DESCRIPTION
# Prelude

Thank you for helping out vim-doge!

<!--
Replace [ ] with [x] with those you agree with.
-->

By contributing to vim-doge you agree to the following statements:

- [x ] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [ x] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

In its current state the parser does not work with the struct keyword in C#.
This change also matches struct_declaration, allowing the generator to function there as well.
