### PR TITLE
Add doc generation for interface in C#

### DIFF
--- a/helper/src/csharp/docs/xmldoc.yaml
+++ b/helper/src/csharp/docs/xmldoc.yaml
@@ -27,6 +27,7 @@ templates:
       - property_declaration
       - field_declaration
       - enum_declaration
+      - interface_declaration
     template: |
       /// <summary>
       /// [TODO:description]

--- a/helper/src/csharp/parser.rs
+++ b/helper/src/csharp/parser.rs
@@ -44,7 +44,8 @@ impl<'a> CSharpParser<'a> {
                     "variable_declaration" |
                     "property_declaration" |
                     "field_declaration" |
-                    "enum_declaration" => self.empty_parse_result(),
+                    "enum_declaration" |
+                    "interface_declaration" => self.empty_parse_result(),
 
                     _ => None,
                 };


### PR DESCRIPTION
# Prelude

Thank you for helping out vim-doge!

By contributing to vim-doge you agree to the following statements:

- [ x] I have read and understood the [Contribution Guidelines](https://github.com/kkoomen/vim-doge/blob/master/CONTRIBUTING.md).
- [x ] I have read and understood the [Code of Conduct](https://github.com/kkoomen/vim-doge/blob/master/CODE_OF_CONDUCT.md).

# Why this PR?

This change allows summary generation for interface declaration in c#.